### PR TITLE
Profile tab, rescue: fixed some more limits (retry)

### DIFF
--- a/src/js/tabs/profiles.js
+++ b/src/js/tabs/profiles.js
@@ -178,6 +178,7 @@ TABS.profiles.initialize = function (callback) {
             const checked = $(this).is(':checked');
             $('.tab-profiles .rescueMode .suboption').toggle(checked);
             $('.tab-profiles .rescueMode .subhelp').toggle(checked);
+            $('.tab-profiles .rescueMode .BaroEnable').toggle(checked);
         });
 
         rescueModeCheck.prop('checked', FC.PID_PROFILE.rescueMode > 0).change();

--- a/src/tabs/profiles.html
+++ b/src/tabs/profiles.html
@@ -442,7 +442,7 @@
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescuePullupTimeHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescuePullupTime" step="0.1" min="0" max="250"/>
+                                        <input type="number" id="rescuePullupTime" step="0.1" min="0" max="25"/>
                                         <label for="rescuePullupTime">
                                             <span i18n="profilesRescuePullupTime"></span>
                                         </label>
@@ -456,7 +456,7 @@
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescueClimbTimeHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueClimbTime" step="0.1" min="0" max="250"/>
+                                        <input type="number" id="rescueClimbTime" step="0.1" min="0" max="25"/>
                                         <label for="rescueClimbTime">
                                             <span i18n="profilesRescueClimbTime"></span>
                                         </label>
@@ -470,14 +470,14 @@
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescueFlipTimeHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueFlipTime" step="0.1" min="0" max="250"/>
+                                        <input type="number" id="rescueFlipTime" step="0.1" min="0" max="25"/>
                                         <label for="rescueFlipTime">
                                             <span i18n="profilesRescueFlipTime"></span>
                                         </label>
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescueExitTimeHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueExitTime" step="0.1" min="0" max="250"/>
+                                        <input type="number" id="rescueExitTime" step="0.1" min="0" max="25"/>
                                         <label for="rescueExitTime">
                                             <span i18n="profilesRescueExitTime"></span>
                                         </label>
@@ -498,14 +498,14 @@
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescueMaxRateHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueMaxRate" step="1" min="10" max="1000"/>
+                                        <input type="number" id="rescueMaxRate" step="10" min="1" max="1000"/>
                                         <label for="rescueMaxRate">
                                             <span i18n="profilesRescueMaxRate"></span>
                                         </label>
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesRescueMaxAccelHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueMaxAccel" step="1" min="10" max="10000"/>
+                                        <input type="number" id="rescueMaxAccel" step="10" min="1" max="10000"/>
                                         <label for="rescueMaxAccel">
                                             <span i18n="profilesRescueMaxAccel"></span>
                                         </label>
@@ -515,7 +515,7 @@
                             <tr class="rescueMode BaroEnable">
                                 <td></td>
                                 <td colspan="2">
-                              <div class="note invoption">
+                                    <div class="note invoption">
                                         <p i18n="baroConfigurationNote"></p>
                                     </div>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesrescueHoverAltitudeHelp"></div>
@@ -534,7 +534,7 @@
                                     </span>
                                     <div class="helpicon cf_tip subhelp" i18n_title="profilesrescueAltitudeIGainHelp"></div>
                                     <span class="suboption">
-                                        <input type="number" id="rescueAltitudeIGain" step="10" min="0" max="50000"/>
+                                        <input type="number" id="rescueAltitudeIGain" step="10" min="0" max="10000"/>
                                         <label for="rescueAltitudeIGain">
                                             <span i18n="profilesrescueAltitudeIGain"></span>
                                         </label>


### PR DESCRIPTION
After making a Lua RF2 rescue page I compared it to the configurator and noticed that there were still some incorrect limits. Also fixed a bug where the rescue barometer settings weren't hidden when rescue was disabled.