### PR TITLE
fix: firmware flasher

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -993,51 +993,6 @@ TABS.firmware_flasher.initialize = function (callback) {
             }
         }
 
-        $('span.progressLabel a.save_firmware').click(function () {
-            var summary = $('select[name="firmware_version"] option:selected').data('summary');
-            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
-                if (checkChromeRuntimeError()) {
-                    return;
-                }
-
-                chrome.fileSystem.getDisplayPath(fileEntry, function (path) {
-                    console.log('Saving firmware to: ' + path);
-
-                    // check if file is writable
-                    chrome.fileSystem.isWritableEntry(fileEntry, function (isWritable) {
-                        if (isWritable) {
-                            var blob = new Blob([self.intel_hex], {type: 'text/plain'});
-
-                            fileEntry.createWriter(function (writer) {
-                                var truncated = false;
-
-                                writer.onerror = function (e) {
-                                    console.error(e);
-                                };
-
-                                writer.onwriteend = function() {
-                                    if (!truncated) {
-                                        // onwriteend will be fired again when truncation is finished
-                                        truncated = true;
-                                        writer.truncate(blob.size);
-
-                                        return;
-                                    }
-                                };
-
-                                writer.write(blob);
-                            }, function (e) {
-                                console.error(e);
-                            });
-                        } else {
-                            console.log('You don\'t have write permissions for this file, sorry.');
-                            GUI.log(i18n.getMessage('firmwareFlasherWritePermissions'));
-                        }
-                    });
-                });
-            });
-        });
-
         $('input.flash_on_connect').change(function () {
             var status = $(this).is(':checked');
 
@@ -1141,6 +1096,50 @@ TABS.firmware_flasher.flashingMessage = function(message, type) {
     }
     if (message != null) {
         progressLabel_e.html(message);
+        $('span.progressLabel a.save_firmware').click(function () {
+            var summary = $('select[name="firmware_version"] option:selected').data('summary');
+            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
+                if (checkChromeRuntimeError()) {
+                    return;
+                }
+
+                chrome.fileSystem.getDisplayPath(fileEntry, function (path) {
+                    console.log('Saving firmware to: ' + path);
+
+                    // check if file is writable
+                    chrome.fileSystem.isWritableEntry(fileEntry, function (isWritable) {
+                        if (isWritable) {
+                            var blob = new Blob([self.intel_hex], {type: 'text/plain'});
+
+                            fileEntry.createWriter(function (writer) {
+                                var truncated = false;
+
+                                writer.onerror = function (e) {
+                                    console.error(e);
+                                };
+
+                                writer.onwriteend = function() {
+                                    if (!truncated) {
+                                        // onwriteend will be fired again when truncation is finished
+                                        truncated = true;
+                                        writer.truncate(blob.size);
+
+                                        return;
+                                    }
+                                };
+
+                                writer.write(blob);
+                            }, function (e) {
+                                console.error(e);
+                            });
+                        } else {
+                            console.log('You don\'t have write permissions for this file, sorry.');
+                            GUI.log(i18n.getMessage('firmwareFlasherWritePermissions'));
+                        }
+                    });
+                });
+            });
+        });
     }
 
     return self;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -425,7 +425,9 @@ TABS.firmware_flasher.initialize = function (callback) {
         function grabBuildNameFromConfig(config) {
             let bareBoard;
             try {
-                bareBoard = config.split("\n")[0].split(' ')[3];
+                const pattern = /.+\/ (STM32[^ ]*)/;
+                const matches = config.match(pattern);
+                bareBoard = matches[1];
             } catch (e) {
                 bareBoard = undefined;
                 console.log('grabBuildNameFromConfig failed: ', e.message);


### PR DESCRIPTION
Fixes for the Firmware Flasher tab:
- Saving the firmware now works again
- Fixed the empty firmware version select when using a cached version of the config (grabBuildNameFromConfig was expecting the MCU name on the first config line, which isn't the case with a cached config)
