### PR TITLE
OpenYGE - added "OpenYGE" to ESC telemetry protocol list

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -29,6 +29,7 @@ TABS.motors = {
         "OMPHobby",
         "ZTW",
         "APD",
+        "OpenYGE",
         "Custom",
     ],
     govModes: [


### PR DESCRIPTION
Added option "OpenYGE" to ESC telemetry protocol list on [ Motors ] page 

Relates to https://github.com/rotorflight/rotorflight-firmware/pull/77

<img width="554" alt="Screenshot 2024-02-14 at 9 01 52 PM" src="https://github.com/rotorflight/rotorflight-configurator/assets/4014433/c32dba52-42a5-4992-bda3-adfe7bba5bfc">
