### PR TITLE
Replace message 'Throttle value for arming' with 'Throttle limit for arming'

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -2035,8 +2035,8 @@
         "english": "The maximum value (in µs) for stick deflection from the center, for RPY."
     },
     "receiverArmingThrottle": {
-        "message": "Gaskanal Wert für Arming",
-        "english": "Throttle Channel value for arming"
+        "message": "Gaskanal Grenze für Arming",
+        "english": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "Kanalwert in µs, unter welchem Arming erlaubt ist.",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1644,7 +1644,7 @@
         "message": "The maximum value (in µs) for stick deflection from the center, for RPY."
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming"
+        "message": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "The channel value (in µs) under which arming is allowed"

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -2564,8 +2564,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -2035,8 +2035,8 @@
         "english": "The maximum value (in µs) for stick deflection from the center, for RPY."
     },
     "receiverArmingThrottle": {
-        "message": "Valeur du canal de commande des gazs pour l'armement",
-        "english": "Throttle Channel value for arming"
+        "message": "Limite du canal de commande des gazs pour l'armement",
+        "english": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "La valeur du canal (en µs) sous laquelle l'armement est autorisé",

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -2564,8 +2564,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -2564,8 +2564,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -2564,8 +2564,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -2035,8 +2035,8 @@
         "english": "The maximum value (in µs) for stick deflection from the center, for RPY."
     },
     "receiverArmingThrottle": {
-        "message": "Throttle kanaalwaarde voor arming",
-        "english": "Throttle Channel value for arming"
+        "message": "Throttle kanaalbegrenzing voor arming",
+        "english": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "De kanaalwaarde (in µs) waaronder arming is toegestaan",

--- a/locales/pl/messages.json
+++ b/locales/pl/messages.json
@@ -2544,8 +2544,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -2564,8 +2564,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/pt_BR/messages.json
+++ b/locales/pt_BR/messages.json
@@ -2543,8 +2543,8 @@
         "status": "New entry. Please translate!"
     },
     "receiverArmingThrottle": {
-        "message": "Throttle Channel value for arming",
-        "english": "Throttle Channel value for arming",
+        "message": "Throttle Channel limit for arming",
+        "english": "Throttle Channel limit for arming",
         "status": "New entry. Please translate!"
     },
     "receiverHelpArmingThrottle": {

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -2036,7 +2036,7 @@
     },
     "receiverArmingThrottle": {
         "message": "解锁油门通道值",
-        "english": "Throttle Channel value for arming"
+        "english": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "允许解锁的通道值（以µs为单位）",

--- a/locales/zh_TW/messages.json
+++ b/locales/zh_TW/messages.json
@@ -2036,7 +2036,7 @@
     },
     "receiverArmingThrottle": {
         "message": "解鎖油門通道值",
-        "english": "Throttle Channel value for arming"
+        "english": "Throttle Channel limit for arming"
     },
     "receiverHelpArmingThrottle": {
         "message": "允許解鎖的通道值（以µs為單位）",


### PR DESCRIPTION
Rephrase menu message text to 'Throttle limit for arming' in order to make it a little bit clearer for new users what this actually is all about.
Chinese messages not touched. Not sure NL translation is correct, copied directly from google translate. 
