### PR TITLE
Serial Rx and Telemetry Pin Swap configuration support

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1634,6 +1634,9 @@
     "receiverSerialInverted": {
         "message": "Inverted Serial Signaling"
     },
+    "receiverSerialPinSwap": {
+        "message": "Pin Swap (Swap Rx and Tx pins)"
+    },
     "receiverStickCenter": {
         "message": "Stick Center"
     },
@@ -1687,6 +1690,9 @@
     },
     "receiverTelemetryInverted": {
         "message": "Inverted Telemetry Signaling"
+    },
+    "receiverTelemetryPinSwap": {
+        "message": "Telemetry Pin Swap (Swap Rx and Tx pins)"
     },
     "receiverCrsfTelemetryMode": {
         "message": "Enable CRSF Custom Telemetry"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -336,6 +336,7 @@ const FC = {
         this.ESC_SENSOR_CONFIG = {
             protocol:                   0,
             half_duplex:                0,
+            pinswap:                    0,
             update_hz:                  0,
             current_offset:             0,
             pinswap:                    0,
@@ -655,6 +656,7 @@ const FC = {
             serialrx_provider:            0,
             serialrx_inverted:            0,
             serialrx_halfduplex:          0,
+            serialrx_pinswap:             0,
             rx_pulse_min:                 0,
             rx_pulse_max:                 0,
             rxSpiProtocol:                0,
@@ -685,6 +687,7 @@ const FC = {
         this.TELEMETRY_CONFIG = {
             telemetry_inverted:             0,
             telemetry_halfduplex:           0,
+            telemetry_pinswap:              0,
             telemetry_sensors:              0,
             telemetry_pinswap:              0,
             crsf_telemetry_mode:            0,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -336,7 +336,6 @@ const FC = {
         this.ESC_SENSOR_CONFIG = {
             protocol:                   0,
             half_duplex:                0,
-            pinswap:                    0,
             update_hz:                  0,
             current_offset:             0,
             pinswap:                    0,
@@ -656,7 +655,6 @@ const FC = {
             serialrx_provider:            0,
             serialrx_inverted:            0,
             serialrx_halfduplex:          0,
-            serialrx_pinswap:             0,
             rx_pulse_min:                 0,
             rx_pulse_max:                 0,
             rxSpiProtocol:                0,
@@ -687,7 +685,6 @@ const FC = {
         this.TELEMETRY_CONFIG = {
             telemetry_inverted:             0,
             telemetry_halfduplex:           0,
-            telemetry_pinswap:              0,
             telemetry_sensors:              0,
             telemetry_pinswap:              0,
             crsf_telemetry_mode:            0,

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -661,9 +661,6 @@ TABS.receiver.initialize = function (callback) {
         const serialRxInvertedElement = $('input[name="serial_inverted"]');
         serialRxInvertedElement.change(function () {
             const inverted = $(this).is(':checked') ? 1 : 0;
-            if (FC.RX_CONFIG.serialrx_inverted !== inverted) {
-                updateButtons(true);
-            }
             FC.RX_CONFIG.serialrx_inverted = inverted;
         });
 
@@ -672,9 +669,6 @@ TABS.receiver.initialize = function (callback) {
         const serialRxHalfDuplexElement = $('input[name="serial_half_duplex"]');
         serialRxHalfDuplexElement.change(function () {
             const halfduplex = $(this).is(':checked') ? 1 : 0;
-            if (FC.RX_CONFIG.serialrx_halfduplex !== halfduplex) {
-                updateButtons(true);
-            }
             FC.RX_CONFIG.serialrx_halfduplex = halfduplex;
         });
 
@@ -683,9 +677,6 @@ TABS.receiver.initialize = function (callback) {
         const serialRxPinswapElement = $('input[name="serial_pinswap"]');
         serialRxPinswapElement.on("change", function () {
             const pinswap = $(this).is(':checked') ? 1 : 0;
-            if (FC.RX_CONFIG.serialrx_pinswap !== pinswap) {
-                updateButtons(true);
-            }
             FC.RX_CONFIG.serialrx_pinswap = pinswap;
         });
 
@@ -924,9 +915,6 @@ TABS.receiver.initialize = function (callback) {
         const telemetryInvertedElement = $('input[name="telemetry_inverted"]');
         telemetryInvertedElement.on("change", function () {
             const inverted = $(this).is(':checked') ? 1 : 0;
-            if (FC.TELEMETRY_CONFIG.telemetry_inverted !== inverted) {
-                updateButtons(true);
-            }
             FC.TELEMETRY_CONFIG.telemetry_inverted = inverted;
         });
 
@@ -935,9 +923,6 @@ TABS.receiver.initialize = function (callback) {
         const telemetryHalfDuplexElement = $('input[name="telemetry_half_duplex"]');
         telemetryHalfDuplexElement.change(function () {
             const halfduplex = $(this).is(':checked') ? 1 : 0;
-            if (FC.TELEMETRY_CONFIG.telemetry_halfduplex !== halfduplex) {
-                updateButtons(true);
-            }
             FC.TELEMETRY_CONFIG.telemetry_halfduplex = halfduplex;
         });
 
@@ -946,9 +931,6 @@ TABS.receiver.initialize = function (callback) {
         const telemetryPinswapElement = $('input[name="telemetry_pinswap"]');
         telemetryPinswapElement.on("change", function () {
             const pinswap = $(this).is(':checked') ? 1 : 0;
-            if (FC.TELEMETRY_CONFIG.telemetry_pinswap !== pinswap) {
-                updateButtons(true);
-            }
             FC.TELEMETRY_CONFIG.telemetry_pinswap = pinswap;
         });
 
@@ -1264,7 +1246,7 @@ TABS.receiver.initialize = function (callback) {
         self.initModelPreview();
         self.renderModel();
 
-        $('.content_wrapper').change(function () {
+        $('.content_wrapper').on("change", function () {
             self.saveButtons = true;
             updateButtons(true);
         });

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -680,6 +680,17 @@ TABS.receiver.initialize = function (callback) {
 
         serialRxHalfDuplexElement.prop('checked', FC.RX_CONFIG.serialrx_halfduplex !== 0);
 
+        const serialRxPinswapElement = $('input[name="serial_pinswap"]');
+        serialRxPinswapElement.on("change", function () {
+            const pinswap = $(this).is(':checked') ? 1 : 0;
+            if (FC.RX_CONFIG.serialrx_pinswap !== pinswap) {
+                updateButtons(true);
+            }
+            FC.RX_CONFIG.serialrx_pinswap = pinswap;
+        });
+
+        serialRxPinswapElement.prop('checked', FC.RX_CONFIG.serialrx_pinswap !== 0);
+
 
     //// Telemetry Options
 
@@ -909,6 +920,39 @@ TABS.receiver.initialize = function (callback) {
         });
 
         rxProtoSelectElement.on('change', updateTelemetry);
+
+        const telemetryInvertedElement = $('input[name="telemetry_inverted"]');
+        telemetryInvertedElement.on("change", function () {
+            const inverted = $(this).is(':checked') ? 1 : 0;
+            if (FC.TELEMETRY_CONFIG.telemetry_inverted !== inverted) {
+                updateButtons(true);
+            }
+            FC.TELEMETRY_CONFIG.telemetry_inverted = inverted;
+        });
+
+        telemetryInvertedElement.prop('checked', FC.TELEMETRY_CONFIG.telemetry_inverted !== 0);
+
+        const telemetryHalfDuplexElement = $('input[name="telemetry_half_duplex"]');
+        telemetryHalfDuplexElement.change(function () {
+            const halfduplex = $(this).is(':checked') ? 1 : 0;
+            if (FC.TELEMETRY_CONFIG.telemetry_halfduplex !== halfduplex) {
+                updateButtons(true);
+            }
+            FC.TELEMETRY_CONFIG.telemetry_halfduplex = halfduplex;
+        });
+
+        telemetryHalfDuplexElement.prop('checked', FC.TELEMETRY_CONFIG.telemetry_halfduplex !== 0);
+
+        const telemetryPinswapElement = $('input[name="telemetry_pinswap"]');
+        telemetryPinswapElement.on("change", function () {
+            const pinswap = $(this).is(':checked') ? 1 : 0;
+            if (FC.TELEMETRY_CONFIG.telemetry_pinswap !== pinswap) {
+                updateButtons(true);
+            }
+            FC.TELEMETRY_CONFIG.telemetry_pinswap = pinswap;
+        });
+
+        telemetryPinswapElement.prop('checked', FC.TELEMETRY_CONFIG.telemetry_pinswap !== 0);
 
 
     //// Channels Bars

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -35,6 +35,10 @@
                                     <td><input type="checkbox" class="toggle" name="serial_half_duplex"/></td>
                                     <td><span i18n="receiverSerialHalfDuplex"></span></td>
                                 </tr>
+                                <tr>
+                                    <td><input type="checkbox" class="toggle" name="serial_pinswap"/></td>
+                                    <td><span i18n="receiverSerialPinSwap"></span></td>
+                                </tr>
                             </table>
                         </div>
                     </div>
@@ -150,6 +154,10 @@
                                 <tr>
                                     <td><input type="checkbox" class="toggle" name="telemetry_half_duplex"/></td>
                                     <td><span i18n="receiverTelemetryHalfDuplex"></span></td>
+                                </tr>
+                                <tr>
+                                    <td><input type="checkbox" class="toggle" name="telemetry_pinswap"/></td>
+                                    <td><span i18n="receiverTelemetryPinSwap"></span></td>
                                 </tr>
                             </table>
                         </div>


### PR DESCRIPTION
Add support for setting Pin swap for serialrx and telemetry on the receiver page

(vtx is not supported via configurator, and esc_sensor_config currently via configurator only allows setting protocol, leaving this to be CLI-only for now)

To support: https://github.com/rotorflight/rotorflight-firmware/commit/240a40e6167455e7d6ea3bfe6c728439696f1c92

<img width="1840" alt="Screenshot 2024-08-09 at 9 53 38 AM" src="https://github.com/user-attachments/assets/bee9c61f-68b6-4867-bea4-a9c5f6e9cbd8">
