### PR TITLE
Add dialog for invalid board name

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3906,6 +3906,18 @@
     "firmwareFlasherBoardDetectionInProgress": {
         "message": "Auto-detecting board for connected device..."
     },
+    "dialogAutoDetectedInvalidBoardNameTitle": {
+        "message": "Invalid Board Name Detected"
+    },
+    "dialogAutoDetectedInvalidBoardNameContent": {
+        "message": "Detected board: ($1) contains invalid characters, and no matching target was found. Attempt detection with corrected board name: ($2)?."
+    },
+    "dialogAutoDetectedInvalidBoardNameAttemptRemap": {
+        "message": "Use Corrected Board Name"
+    },
+    "dialogAutoDetectedInvalidBoardNameIgnore": {
+        "message": "Ignore Invalid Board Name"
+    },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip.<br />Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved.<br />Double-click on a color to edit the HSV values."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3906,17 +3906,17 @@
     "firmwareFlasherBoardDetectionInProgress": {
         "message": "Auto-detecting board for connected device..."
     },
-    "dialogAutoDetectedInvalidBoardNameTitle": {
+    "dialogBoardDetectionMessageInvalidBoardNameTitle": {
         "message": "Invalid Board Name Detected"
     },
-    "dialogAutoDetectedInvalidBoardNameContent": {
-        "message": "Detected board: ($1) contains invalid characters, and no matching target was found. Attempt detection with corrected board name: ($2)?."
+    "dialogBoardDetectionMessageInvalidBoardNameContent": {
+        "message": "Board name: ($1) contains invalid characters -- using corrected board name: ($2)"
     },
-    "dialogAutoDetectedInvalidBoardNameAttemptRemap": {
-        "message": "Use Corrected Board Name"
+    "dialogBoardDetectionMessageInvalidBoardNameRecommendation": {
+        "message": "A full chip erase is recommended to correct the board name. Ensure you perform a full backup before performing a flash with full chip erase enabled."
     },
-    "dialogAutoDetectedInvalidBoardNameIgnore": {
-        "message": "Ignore Invalid Board Name"
+    "dialogBoardDetectionMessageAcknowledge": {
+        "message": "Acknowledge"
     },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip.<br />Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved.<br />Double-click on a color to edit the HSV values."

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -178,4 +178,13 @@
             </div>
         </div>
     </dialog>
+
+    <dialog id="dialogAutoDetectedInvalidBoardName">
+        <h3 i18n="dialogAutoDetectedInvalidBoardNameTitle"></h3>
+        <div class="content" id="dialogAutoDetectedInvalidBoardNameContent"></div>
+        <div class="buttons">
+            <a href="#" id="dialogAutoDetectedInvalidBoardNameAttemptRemap" class="regular-button" i18n="dialogAutoDetectedInvalidBoardNameAttemptRemap"></a>
+            <a href="#" id="dialogAutoDetectedInvalidBoardNameIgnore" class="regular-button" i18n="dialogAutoDetectedInvalidBoardNameIgnore"></a>
+        </div>
+    </dialog>
 </div>

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -179,12 +179,11 @@
         </div>
     </dialog>
 
-    <dialog id="dialogAutoDetectedInvalidBoardName">
-        <h3 i18n="dialogAutoDetectedInvalidBoardNameTitle"></h3>
-        <div class="content" id="dialogAutoDetectedInvalidBoardNameContent"></div>
+    <dialog id="dialogBoardDetectionMessage">
+        <h3 id="dialogBoardDetectionMessageTitle"></h3>
+        <div class="content" id="dialogBoardDetectionMessageContent"></div>
         <div class="buttons">
-            <a href="#" id="dialogAutoDetectedInvalidBoardNameAttemptRemap" class="regular-button" i18n="dialogAutoDetectedInvalidBoardNameAttemptRemap"></a>
-            <a href="#" id="dialogAutoDetectedInvalidBoardNameIgnore" class="regular-button" i18n="dialogAutoDetectedInvalidBoardNameIgnore"></a>
+            <a href="#" id="dialogBoardDetectionMessageAcknowledge" class="regular-button" i18n="dialogBoardDetectionMessageAcknowledge"></a>
         </div>
     </dialog>
 </div>


### PR DESCRIPTION
This PR adds a dialog which informs about a backend correction to board name if an invalid one was detected. This issue was hit when looking at the FlyDragonRC F722V2.2, where the first batch had its target board name set to `FLYDRAGONF722_V2.2` which is invalid.

It also reverts the unintentional removal of the erase_all functionality within the firmware flasher.

Various cases:

## Invalid board name (`FLYDRAGONF722_V2.2`)
<img width="2000" alt="Screenshot 2024-08-16 at 9 28 37 AM" src="https://github.com/user-attachments/assets/577d5da5-3f49-4416-b358-e174b7e82ec5">

## Unknown board (`UNKNOWN_BOARD`)
<img width="2000" alt="Screenshot 2024-08-16 at 9 30 07 AM" src="https://github.com/user-attachments/assets/2c8c9ee7-731c-4c4e-823c-6faccfed4b1c">

## Valid board (`FLYDRAGONF722_V2_2`)
<img width="2000" alt="Screenshot 2024-08-16 at 9 31 23 AM" src="https://github.com/user-attachments/assets/770144c1-59af-42e3-a887-32b8321d9165">

