### PR TITLE
feat: added tooltips for accelerometer trims

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1240,13 +1240,19 @@
         "message": "Accelerometer Trim"
     },
     "configurationAccelTrimsHelp": {
-        "message": "The Accelerometer Trims provide fine tuning to the horizon level, which can be used to decrease drift while in stabilized modes, such as Angle or Rescue."
+        "message": "Accelerometer Trims adjust the horizon to correct drift in stabilized modes like Angle, Horizon, and Rescue."
     },
     "configurationAccelTrimRoll": {
         "message": "Accelerometer Roll Trim"
     },
+    "configurationAccelRollTrimHelp": {
+        "message": "Increase the value to correct drift to the left. Decrease the value (or use negative values) to correct drift to the right."
+    },
     "configurationAccelTrimPitch": {
         "message": "Accelerometer Pitch Trim"
+    },
+    "configurationAccelPitchTrimHelp": {
+        "message": "Increase the value to correct drift to the rear. Decrease the value (or use negative values) to correct drift to the front."
     },
     "escProtocolDisabledMessage": {
         "message": "<strong>Caution:</strong> Selecting a motor output protocol that is not supported by your ESCs can lead to the <strong>ESCs spinning up as soon as a battery is connected</strong>. For this reason, <strong>always make sure to remove the props before connecting a battery for the first time after changing the motor output protocol</strong>."

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -205,11 +205,13 @@
                             <label> <input type="number" name="roll" min="-300" max="300" /> <span
                                 i18n="configurationAccelTrimRoll"></span>
                             </label>
+                            <div class="helpicon cf_tip" i18n_title="configurationAccelRollTrimHelp"></div>
                         </div>
                         <div class="number">
                             <label> <input type="number" name="pitch" min="-300" max="300" /> <span
                                 i18n="configurationAccelTrimPitch"></span>
                             </label>
+                            <div class="helpicon cf_tip" i18n_title="configurationAccelPitchTrimHelp"></div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added tooltips so users know what to input to correct for drift in stabilized modes, see #171.