### PR TITLE
Update three.js to 0.169.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
     "multiple-select": "^1.5.2",
     "select2": "^4.0.13",
     "semver-min": "^0.7.2",
-    "switchery-latest": "^0.8.2",
-    "three": "^0.126.1"
+    "switchery-latest": "^0.8.2"
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
@@ -83,6 +82,7 @@
     "nw-vue-devtools-prebuilt": "^0.0.10",
     "postcss": "^8.4.14",
     "rpm-builder": "^1.2.1",
+    "three": "^0.169.0",
     "vinyl-source-stream": "^2.0.0",
     "vite": "^5.4.0",
     "vue": "^2.7.0",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -155,7 +155,7 @@ function startProcess() {
     document.createElement('canvas');
 
     // log library versions in console to make version tracking easier
-    console.log(`Libraries: jQuery - ${$.fn.jquery}, d3 - ${d3.version}, three.js - ${THREE.REVISION}`);
+    console.log(`Libraries: jQuery - ${$.fn.jquery}, d3 - ${d3.version}`);
 
     if (GUI.isCordova()) {
         UI_PHONES.init();

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -1,3 +1,6 @@
+import * as THREE from "three";
+import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
+
 // 3D model
 export const Model = function (wrapper, canvas) {
 
@@ -11,8 +14,7 @@ export const Model = function (wrapper, canvas) {
     // initialize render size for current canvas size
     this.renderer.setSize(this.wrapper.width() * 2, this.wrapper.height() * 2);
 
-    // Set output encoding for GLTF model format
-    this.renderer.outputEncoding = THREE.sRGBEncoding;
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
 
     // model file name
     var model_file = 'fallback';
@@ -54,7 +56,7 @@ export const Model = function (wrapper, canvas) {
 };
 
 Model.prototype.loadGLTF = function (model_file, callback) {
-    const loader = new THREE.GLTFLoader();
+    const loader = new GLTFLoader();
     loader.load('/resources/models/' + model_file + '.gltf', function (gltf) {
         callback(gltf.scene);
     });

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -35,8 +35,8 @@ export const Model = function (wrapper, canvas) {
     this.camera.position.z = 800;
 
     // some light
-    const light = new THREE.AmbientLight(0x404040);
-    const light2 = new THREE.DirectionalLight(new THREE.Color(1, 1, 1), 1.5);
+    const light = new THREE.AmbientLight(0x404040, 20);
+    const light2 = new THREE.DirectionalLight(new THREE.Color(1, 1, 1), 5);
     light2.position.set(0, 1, 0);
 
     // add camera, model, light to the foreground scene

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -1,7 +1,5 @@
-'use strict';
-
 // 3D model
-const Model = function (wrapper, canvas) {
+export const Model = function (wrapper, canvas) {
 
     const flip = (FC.MIXER_CONFIG.main_rotor_dir == 0);
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1,3 +1,5 @@
+import { Model } from "@/js/model.js";
+
 const tab = {
     tabName: 'configuration',
     isDirty: false,

--- a/src/js/tabs/rates.js
+++ b/src/js/tabs/rates.js
@@ -1,3 +1,5 @@
+import { Clock } from "three";
+
 import { Model } from "@/js/model.js";
 
 const tab = {
@@ -494,7 +496,7 @@ tab.renderModel = function () {
         requestAnimationFrame(self.renderModel.bind(self));
     }
     if (!self.clock) {
-        self.clock = new THREE.Clock();
+        self.clock = new Clock();
     }
 
     if (self.rcChannels[0] && self.rcChannels[1] && self.rcChannels[2]) {

--- a/src/js/tabs/rates.js
+++ b/src/js/tabs/rates.js
@@ -1,3 +1,5 @@
+import { Model } from "@/js/model.js";
+
 const tab = {
     tabName: 'rates',
     isDirty: false,

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -1,3 +1,5 @@
+import { Model } from "@/js/model.js";
+
 const tab = {
     tabName: 'receiver',
     isDirty: false,

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -1,3 +1,5 @@
+import { Clock } from "three";
+
 import { Model } from "@/js/model.js";
 
 const tab = {
@@ -1298,7 +1300,7 @@ tab.initModelPreview = function () {
     const self = this;
 
     self.model = new Model($('#canvas_wrapper'), $('#canvas'));
-    self.clock = new THREE.Clock();
+    self.clock = new Clock();
     self.rateCurve = new RateCurve2();
     self.keepRendering = true;
 

--- a/src/js/tabs/status.js
+++ b/src/js/tabs/status.js
@@ -1,3 +1,5 @@
+import { Model } from "@/js/model.js";
+
 const tab = {
     tabName: 'status',
     armingEnabled: true,

--- a/src/main.html
+++ b/src/main.html
@@ -73,7 +73,6 @@
     <script type="text/javascript" src="/src/js/gui.js"></script>
     <script type="text/javascript" src="/src/js/huffman.js"></script>
     <script type="text/javascript" src="/src/js/default_huffman_tree.js"></script>
-    <script type="text/javascript" src="/src/js/model.js"></script>
     <script type="text/javascript" src="/src/js/serial_backend.js"></script>
     <script type="text/javascript" src="/src/js/msp/MSPCodes.js"></script>
     <script type="text/javascript" src="/src/js/msp/MSPConnector.js"></script>

--- a/src/main.html
+++ b/src/main.html
@@ -51,9 +51,6 @@
     <script type="text/javascript" src="/node_modules/jbox/dist/jBox.min.js"></script>
     <script type="text/javascript" src="/node_modules/jquery-ui-npm/jquery-ui.min.js"></script>
     <script type="text/javascript" src="/libraries/d3.min.js"></script>
-    <script type="text/javascript" src="/node_modules/three/build/three.min.js"></script>
-    <script type="text/javascript" src="/node_modules/three/build/three.module.js"></script>
-    <script type="text/javascript" src="/node_modules/three/examples/js/loaders/GLTFLoader.js"></script>
     <script type="text/javascript" src="/libraries/jquery.flightindicators.js"></script>
     <script type="text/javascript" src="/node_modules/semver-min/umd/index.js"></script>
     <script type="text/javascript" src="/node_modules/switchery-latest/dist/switchery.min.js"></script>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -21,6 +21,13 @@ export default defineConfig({
         "src/main_cordova.html": "src/main_cordova.html",
         "src/tabs/receiver_msp.html": "src/tabs/receiver_msp.html",
       },
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/three")) {
+            return "vendor-three";
+          }
+        },
+      },
     },
   },
   plugins: [vue()],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6821,10 +6821,10 @@ textextensions@^3.2.0:
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-3.3.0.tgz#03530d5287b86773c08b77458589148870cc71d3"
   integrity sha512-mk82dS8eRABNbeVJrEiN5/UMSCliINAuz8mkUwH4SwslkNP//gbEzlWNS5au0z5Dpx40SQxzqZevZkn+WYJ9Dw==
 
-three@^0.126.1:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.1.tgz#cf4e4e52060fd952f6f0d5440cbd422c66bc4be7"
-  integrity sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ==
+three@^0.169.0:
+  version "0.169.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.169.0.tgz#4a62114988ad9728d73526d1f1de6760c56b4adc"
+  integrity sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==
 
 through2-filter@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Converted three usage to ESM, as it is ESM only now.

Lighting strength had to be increased to get a similar affect as the current version.

As a bonus, the application bundle size is reduced by 22.6MiB