### PR TITLE
Update macos runner to macos-13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
 
   macos-x86_64:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Check out repository

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,7 +49,7 @@ jobs:
 
   macos-x86_64:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Check out repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
   macos-x86_64:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Check out repository

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,7 +48,7 @@ jobs:
 
   macos-x86_64:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Check out repository

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -49,7 +49,7 @@ jobs:
 
   macos-x86_64:
 
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Check out repository


### PR DESCRIPTION
The macos-12 based runners will be shut down soon.