### PR TITLE
Hide gov_min_throttle in PASSTHROUGH governor mode

### DIFF
--- a/src/js/tabs/profiles.js
+++ b/src/js/tabs/profiles.js
@@ -579,7 +579,10 @@ tab.initialize = function (callback) {
 
         if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_12_7)) {
             $('.tab-profiles tr.govMinThrottle').hide();
-            $('.tab-profiles tr.govMaxThrottle').addClass('border');
+
+            if(self.isGovActive) {
+                $('.tab-profiles tr.govMaxThrottle').addClass('border');
+            }
         }
 
         function get_status() {

--- a/src/js/tabs/profiles.js
+++ b/src/js/tabs/profiles.js
@@ -412,6 +412,7 @@ tab.initialize = function (callback) {
         // Governor settings
         if (self.isGovActive) {
             FC.GOVERNOR.gov_headspeed = parseInt($('.tab-profiles input[id="govHeadspeed"]').val());
+            FC.GOVERNOR.gov_min_throttle = parseInt($('.tab-profiles input[id="govMinThrottle"]').val());
             FC.GOVERNOR.gov_gain = parseInt($('.tab-profiles input[id="govMasterGain"]').val());
             FC.GOVERNOR.gov_p_gain = parseInt($('.tab-profiles input[id="govPGain"]').val());
             FC.GOVERNOR.gov_i_gain = parseInt($('.tab-profiles input[id="govIGain"]').val());
@@ -423,7 +424,6 @@ tab.initialize = function (callback) {
         }
         if (self.isGovEnabled) {
             FC.GOVERNOR.gov_max_throttle = parseInt($('.tab-profiles input[id="govMaxThrottle"]').val());
-            FC.GOVERNOR.gov_min_throttle = parseInt($('.tab-profiles input[id="govMinThrottle"]').val());
         }
     }
 

--- a/src/tabs/profiles.html
+++ b/src/tabs/profiles.html
@@ -803,7 +803,7 @@
                                     <div class="helpicon cf_tip" i18n_title="govMaxThrottleHelp"></div>
                                 </td>
                             </tr>
-                            <tr class="govMinThrottle border">
+                            <tr class="govMinThrottle govActive border">
                                 <td>
                                     <input type="number" id="govMinThrottle" min="0" max="100" step="1"/>
                                 </td>


### PR DESCRIPTION
PASSTHROUGH does not appear to use gov_min_throttle, so it should be hidden along with the rest of the active governor parameters.