### PR TITLE
[RF2.1] Reset yaw calibration when switching tail rotor type

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2622,6 +2622,9 @@
     "mixerRebootNote": {
         "message": "<span class=\"message-negative\">Warning:</span> Some settings require System Reboot to take affect!"
     },
+    "mixerMotorisedTailCalibrationNote": {
+        "message": "<span class=\"message-negative\">Warning:</span> Yaw calibration should be 100% when using a motorised tail. Do not change this value unless you know what you are doing."
+    },
     "mixerMainRotorSettings": {
         "message": "Main Rotor Settings"
     },

--- a/src/css/tabs/mixer.css
+++ b/src/css/tabs/mixer.css
@@ -234,6 +234,10 @@
     margin-bottom: 0.5em;
 }
 
+.tab-mixer .mixerMotorisedTailCalibrationNote .note {
+    margin: 4px 0 0;
+}
+
 @media all and (max-width: 575px) {
     .tab-mixer dialog {
         width: calc(100% - 2em);

--- a/src/js/tabs/mixer.js
+++ b/src/js/tabs/mixer.js
@@ -220,6 +220,8 @@ tab.initialize = function (callback) {
     function data_to_form() {
 
         $('.tab-mixer .note').hide();
+        $('.tab-mixer .mixerMotorisedTailCalibrationNote .note').show();
+        $('.tab-mixer .mixerMotorisedTailCalibrationNote').hide();
 
         self.origMixerConfig = Mixer.cloneConfig(FC.MIXER_CONFIG);
         self.origMixerInputs = Mixer.cloneInputs(FC.MIXER_INPUTS);
@@ -338,8 +340,10 @@ tab.initialize = function (callback) {
                 $('#mixerTailMotorCenterTrim').val((FC.MIXER_CONFIG.tail_center_trim * 0.1).toFixed(1));
                 $('.mixerOverrideAxis .mixerTailMotor').addClass('mixerOverrideActive');
                 $('.mixerOverrideAxis .mixerTailRotor').removeClass('mixerOverrideActive');
-                if (change)
+                if (change) {
                     $('.mixerTailMotor .mixerOverrideEnable input').change();
+                    $('#mixerTailRotorCalibration').val(100).change();
+                }
             }
             else {
                 const yawMin = FC.MIXER_INPUTS[3].min * -24/1000;
@@ -349,11 +353,20 @@ tab.initialize = function (callback) {
                 $('#mixerTailRotorCenterTrim').val((FC.MIXER_CONFIG.tail_center_trim * 24/1000).toFixed(1));
                 $('.mixerOverrideAxis .mixerTailRotor').addClass('mixerOverrideActive');
                 $('.mixerOverrideAxis .mixerTailMotor').removeClass('mixerOverrideActive');
-                if (change)
+                if (change) {
                     $('.mixerTailRotor .mixerOverrideEnable input').change();
+                    $('#mixerTailRotorCalibration').val(25).change();
+                }
             }
 
             $('.mixerBidirNote').toggle(mode == 2);
+            updateYawCalibrationNote();
+        }
+
+        function updateYawCalibrationNote() {
+            const motorised = FC.MIXER_CONFIG.tail_rotor_mode > 0;
+            const showNote = motorised && getFloatValue('#mixerTailRotorCalibration') !== 100;
+            $('.tab-mixer .mixerMotorisedTailCalibrationNote').toggle(showNote);
         }
 
         $('#mixerTailRotorMode').change(function () {
@@ -364,7 +377,10 @@ tab.initialize = function (callback) {
         setTailRotorMode(FC.MIXER_CONFIG.tail_rotor_mode, false);
 
         $('#mixerTailRotorDirection').val(yawDir).change();
-        $('#mixerTailRotorCalibration').val(yawRate).change();
+        $('#mixerTailRotorCalibration')
+            .on('change', updateYawCalibrationNote)
+            .val(yawRate)
+            .change();
         $('#mixerTailMotorIdle').val(FC.MIXER_CONFIG.tail_motor_idle / 10).change();
 
         $('.tab-mixer .mixerReboot').change(function() {

--- a/src/tabs/mixer.html
+++ b/src/tabs/mixer.html
@@ -332,6 +332,13 @@
                                         </div>
                                     </td>
                                 </tr>
+                                <tr class="mixerMotorisedTailCalibrationNote">
+                                    <td colspan="2">
+                                        <div class="note">
+                                            <p i18n="mixerMotorisedTailCalibrationNote"></p>
+                                        </div>
+                                    </td>
+                                </tr>
                                 <tr class="mixerTailRotorCalibration">
                                     <td>
                                         <div class="configCol1 mixerInput3">


### PR DESCRIPTION
- Sets yaw calibration to 100% when changing to a motorised or bidirectional tail.
- Sets yaw calibration to 25% when changing to a variable pitch tail.
- Adds a warning message when using a yaw calibration other than 100% with a motorised or bidirectional tail.