### PR TITLE
Add hex_parser.js worker to bundle

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -46,7 +46,7 @@ tab.initialize = function (callback) {
         function parse_hex(str) {
             return new Promise(r => {
                 // parsing hex in different thread
-                var worker = new Worker('/src/js/workers/hex_parser.js');
+                var worker = new Worker(new URL('@/js/workers/hex_parser.js', import.meta.url));
 
                 // "callback"
                 worker.onmessage = function (event) {

--- a/src/js/workers/hex_parser.js
+++ b/src/js/workers/hex_parser.js
@@ -1,5 +1,3 @@
-'use strict';
-
 // input = string
 // result = if hex file is valid, result is an object
 //          if hex file wasn't valid (crc check failed on any of the lines), result will be false


### PR DESCRIPTION
Makes vite add the `hex_parser` worker to the bundle, which fixes firmware flasher failing to parse hex file.