### PR TITLE
remove libgconf-2-4 dependency

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -286,7 +286,6 @@ function build_redist_deb(done) {
         `xdg-desktop-menu install ${LINUX_INSTALL_DIR}/${pkg.name}/${pkg.name}.desktop`,
       ],
       prerm: [`xdg-desktop-menu uninstall ${pkg.name}.desktop`],
-      depends: "libgconf-2-4",
       changelog: [],
       _target: `${LINUX_INSTALL_DIR}/${pkg.name}`,
       _out: REDIST_DIR,
@@ -321,7 +320,6 @@ async function build_redist_rpm() {
     vendor: pkg.author,
     summary: pkg.description,
     license: "GNU General Public License v3.0",
-    requires: "libgconf-2-4",
     prefix: "/opt",
     files: [
       {


### PR DESCRIPTION
NW.js is no longer linked against `libgconf`, so this dependency should be removed from the rpm and deb packages.