### PR TITLE
remove package: node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "i18next-http-backend": "^2.6.1",
     "marked": "^15.0.3",
     "minimist": "^1.2.8",
-    "node-gyp": "^10.2.0",
     "nouislider": "^15.8.1",
     "nw-builder": "4.9.0",
     "postcss": "^8.4.14",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "jquery-touchswipe": "^1.6.19",
     "jquery-ui-npm": "^1.12.0",
     "lru_map": "^0.3.3",
-    "multiple-select": "^1.5.2",
     "select2": "^4.0.13",
     "switchery-latest": "^0.8.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       lru_map:
         specifier: ^0.3.3
         version: 0.3.3
-      multiple-select:
-        specifier: ^1.5.2
-        version: 1.7.0(jquery@3.7.1)
       select2:
         specifier: ^4.0.13
         version: 4.0.13
@@ -2809,11 +2806,6 @@ packages:
 
   multipipe@0.1.2:
     resolution: {integrity: sha512-7ZxrUybYv9NonoXgwoOqtStIu18D1c3eFZj27hqgf5kBrBF8Q+tE8V0MW8dKM5QLkQPh1JhhbKgHLY9kifov4Q==}
-
-  multiple-select@1.7.0:
-    resolution: {integrity: sha512-KlODxbDvsg/3M+xU5pmtJb89dJzK4G3oO2miWMwAbW8UaDHfXi4DoVSRiynqwfSa0znwrT0juKEsxJ2nux7k4A==}
-    peerDependencies:
-      jquery: 1.9.1 - 3
 
   murmur-32@0.2.0:
     resolution: {integrity: sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==}
@@ -7237,10 +7229,6 @@ snapshots:
   multipipe@0.1.2:
     dependencies:
       duplexer2: 0.0.2
-
-  multiple-select@1.7.0(jquery@3.7.1):
-    dependencies:
-      jquery: 3.7.1
 
   murmur-32@0.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
-      node-gyp:
-        specifier: ^10.2.0
-        version: 10.2.0
       nouislider:
         specifier: ^15.8.1
         version: 15.8.1


### PR DESCRIPTION
Pinning node-gyp is no longer required after removing gulp-xml-transformer.