### PR TITLE
Fix timezone calculation

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2150,7 +2150,7 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_RTC: {
             const now = new Date();
             const utc_timestamp = now.getTime();
-            const timestamp = utc_timestamp + now.getTimezoneOffset() * 60000;
+            const timestamp = utc_timestamp - now.getTimezoneOffset() * 60000;
             const secs = timestamp / 1000;
             const millis = timestamp % 1000;
             buffer.push32(secs);


### PR DESCRIPTION
Quote:
> The number of minutes returned by getTimezoneOffset() is positive if the local time zone is behind UTC, and negative if the local time zone is ahead of UTC. For example, for UTC+10, -600 will be returned.