### PR TITLE
Added ESC1 Status, ESC1 & ESC2 Model ID sensors to FrSky telemetry

### DIFF
--- a/src/tabs/receiver/telemetry/smartport.js
+++ b/src/tabs/receiver/telemetry/smartport.js
@@ -41,6 +41,8 @@ export const SMARTPORT_SENSORS = [
       { name: "ESC1_TEMP2" },
       { name: "ESC1_BEC_VOLTAGE" },
       { name: "ESC1_BEC_CURRENT" },
+      { name: "ESC1_STATUS" },
+      { name: "ESC1_MODEL" },
     ],
   },
   {
@@ -51,6 +53,7 @@ export const SMARTPORT_SENSORS = [
       { name: "ESC2_CAPACITY" },
       { name: "ESC2_ERPM" },
       { name: "ESC2_TEMP1" },
+      { name: "ESC2_MODEL" },
     ],
   },
   {


### PR DESCRIPTION
Included ESC1 Status, ESC1 & ESC2 Model ID sensors in FrSky telemetry stream for support of ESC status widget equal to ELRS

Related PRs...
- https://github.com/rotorflight/rotorflight-firmware/pull/261
- https://github.com/rotorflight/rotorflight-lua-ethos-suite/pull/285

e.g.
![image](https://github.com/user-attachments/assets/27ae77b7-7f05-4a1a-9dd4-adfee49c1ddf)
![image](https://github.com/user-attachments/assets/eb756157-c3bf-4616-8fd2-11d903c73529)
