### PR TITLE
fix (windows): do not abort the installation

### DIFF
--- a/assets/windows/installer.iss
+++ b/assets/windows/installer.iss
@@ -120,7 +120,7 @@ begin
     begin
         if not Exec('>', UninstPath, '', SW_SHOW, ewWaitUntilTerminated, ResultCode) then
         begin
-            Result := False;
+            // Result := False; // Set to False to abort the installation
             MsgBox('Error uninstalling Configurator ' + SysErrorMessage(ResultCode) + '.', mbError, MB_OK);
         end;
     end;


### PR DESCRIPTION
Do not abort the installation if uninstalling an old version fails.