### PR TITLE
Handle webgl context creation error.

### DIFF
--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -336,6 +336,17 @@
     height: 100% !important;
 }
 
+.tab-configuration #canvas_wrapper .webgl-error {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: var(--mutedText);
+    font-size: 16px;
+    font-weight: 600;
+}
+
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
     .tab-configuration .gui_box span {
         line-height: 17px;

--- a/src/css/tabs/rates.css
+++ b/src/css/tabs/rates.css
@@ -438,6 +438,17 @@
     background-size: 100%;
 }
 
+.tab-rates .rates_preview .webgl-error {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: var(--mutedText);
+    font-size: 16px;
+    font-weight: 600;
+}
+
 .tab-rates #canvas {
     width: 100% !important;
     height: 100% !important;

--- a/src/css/tabs/receiver.css
+++ b/src/css/tabs/receiver.css
@@ -358,6 +358,17 @@
     bottom: 0;
 }
 
+.tab-receiver #canvas_wrapper .webgl-error {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: var(--mutedText);
+    font-size: 16px;
+    font-weight: 600;
+}
+
 .tab-receiver #canvas {
     width: 100% !important;
     height: 100% !important;

--- a/src/css/tabs/status.css
+++ b/src/css/tabs/status.css
@@ -53,6 +53,17 @@
     border-radius: 5px;
 }
 
+.tab-status #canvas_wrapper .webgl-error {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    color: var(--mutedText);
+    font-size: 16px;
+    font-weight: 600;
+}
+
 .tab-status #canvas {
     width: 100% !important;
     height: 100% !important;

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -703,9 +703,14 @@ tab.initialize = function (callback) {
 };
 
 tab.initModel = function () {
-    this.model = new Model($('.model-and-info #canvas_wrapper'), $('.model-and-info #canvas'));
-
-    $(window).on('resize', $.proxy(this.model.resize, this.model));
+    try {
+        this.model = new Model($('.model-and-info #canvas_wrapper'), $('.model-and-info #canvas'));
+        $('#canvas_wrapper .webgl-error').hide();
+        $(window).on('resize', $.proxy(this.model.resize, this.model));
+    } catch (err) {
+        console.log("Error initialising model", err);
+        $('#canvas_wrapper .webgl-error').show();
+    }
 };
 
 tab.renderModel = function () {
@@ -713,7 +718,7 @@ tab.renderModel = function () {
           y = (-FC.SENSOR_DATA.kinematics[2] - this.yaw_fix) * 0.017453292519943295,
           z = (-FC.SENSOR_DATA.kinematics[0]) * 0.017453292519943295;
 
-    this.model.rotateTo(x, y, z);
+    this.model?.rotateTo(x, y, z);
 };
 
 tab.cleanup = function (callback) {

--- a/src/js/tabs/rates.js
+++ b/src/js/tabs/rates.js
@@ -494,12 +494,17 @@ tab.convertToCollective = function (rate) {
 tab.initRatesPreview = function () {
     this.keepRendering = true;
 
-    this.model = new Model($('.rates_preview'), $('.rates_preview canvas'));
+    try {
+        this.model = new Model($('.rates_preview'), $('.rates_preview canvas'));
+        $('.rates_preview .webgl-error').hide();
+        $('.tab-rates .tab-container .tab').on('click', $.proxy(this.model.resize, this.model));
+        $(window).on('resize', $.proxy(this.model.resize, this.model));
+    } catch (err) {
+        console.log("Error initialising model", err);
+        $('.rates_preview .webgl-error').show();
+    }
 
-    $('.tab-rates .tab-container .tab').on('click', $.proxy(this.model.resize, this.model));
     $('.tab-rates .tab-container .tab').on('click', $.proxy(this.updateRatesLabels, this));
-
-    $(window).on('resize', $.proxy(this.model.resize, this.model));
     $(window).on('resize', $.proxy(this.updateRatesLabels, this));
 };
 
@@ -547,7 +552,7 @@ tab.renderModel = function () {
             self.currentRates.yaw_rate_limit
         );
 
-        self.model.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
+        self.model?.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
 
         if (self.checkChannels()) {
             self.updateRatesLabels();

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -517,7 +517,15 @@ tab.initialize = function (callback) {
 tab.initModelPreview = function () {
     const self = this;
 
-    self.model = new Model($('#canvas_wrapper'), $('#canvas'));
+    try {
+        self.model = new Model($('#canvas_wrapper'), $('#canvas'));
+        $(window).on('resize', $.proxy(self.model.resize, self.model));
+        $('#canvas_wrapper .webgl-error').hide();
+    } catch (err) {
+        console.log("Error initialising model", err);
+        $('#canvas_wrapper .webgl-error').show();
+    }
+
     self.clock = new Clock();
     self.rateCurve = new RateCurve2();
     self.keepRendering = true;
@@ -574,8 +582,6 @@ tab.initModelPreview = function () {
         default:
             break;
     }
-
-    $(window).on('resize', $.proxy(self.model.resize, self.model));
 };
 
 tab.renderModel = function () {
@@ -619,7 +625,7 @@ tab.renderModel = function () {
             self.currentRates.yaw_rate_limit
         );
 
-        self.model.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
+        self.model?.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
     }
 };
 

--- a/src/js/tabs/status.js
+++ b/src/js/tabs/status.js
@@ -327,9 +327,14 @@ tab.initialize = function (callback) {
 
 
 tab.initModel = function () {
-    this.model = new Model($('.model-and-info #canvas_wrapper'), $('.model-and-info #canvas'));
-
-    $(window).on('resize', $.proxy(this.model.resize, this.model));
+    try {
+        this.model = new Model($('.model-and-info #canvas_wrapper'), $('.model-and-info #canvas'));
+        $(window).on('resize', $.proxy(this.model.resize, this.model));
+        $('#canvas_wrapper .webgl-error').hide();
+    } catch (err) {
+        console.log("Error initialising model", err);
+        $('#canvas_wrapper .webgl-error').show();
+    }
 };
 
 tab.renderModel = function () {
@@ -337,7 +342,7 @@ tab.renderModel = function () {
         y = ((FC.SENSOR_DATA.kinematics[2] * -1.0) - this.yaw_fix) * 0.017453292519943295,
         z = (FC.SENSOR_DATA.kinematics[0] * -1.0) * 0.017453292519943295;
 
-    this.model.rotateTo(x, y, z);
+    this.model?.rotateTo(x, y, z);
 };
 
 tab.cleanup = function (callback) {

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -190,6 +190,7 @@
                         <div id="interactive_block">
                             <div id="canvas_wrapper" class="background_paper">
                                 <canvas id="canvas"></canvas>
+                                <div class="webgl-error">WebGL Context Error</div>
                             </div>
                             <a class="reset sm-min" href="#" i18n="statusButtonResetZaxis"></a>
                         </div>

--- a/src/tabs/rates.html
+++ b/src/tabs/rates.html
@@ -258,6 +258,7 @@
                                     <td class="rates_preview_cell">
                                         <div class="rates_preview background_paper">
                                             <canvas id="canvas"></canvas>
+                                            <div class="webgl-error">WebGL Context Error</div>
                                         </div>
                                     </td>
                                 </tr>

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -56,6 +56,7 @@
                     <div class="model_preview background_paper">
                         <div id="canvas_wrapper">
                             <canvas id="canvas"></canvas>
+                            <div class="webgl-error">WebGL Context Error</div>
                         </div>
                     </div>
                 </div>

--- a/src/tabs/status.html
+++ b/src/tabs/status.html
@@ -119,6 +119,7 @@
                                     <dd class="roll">&nbsp;</dd>
                                 </dl>
                             </div>
+                            <div class="webgl-error">WebGL Context Error</div>
                         </div>
                         <a class="reset sm-min" href="#" i18n="statusButtonResetZaxis"></a>
                     </div>


### PR DESCRIPTION
WebGL is used to render the preview model. Display an error message over the canvas instead of crashing when a context could not be created.