### PR TITLE
Update messages.json

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -4444,7 +4444,7 @@
         "english": "Maximum output throttle the governor is allowed to use."
     },
     "govMinThrottle": {
-        "message": "Maximaler Gaswert [%]",
+        "message": "Minimaler Gaswert [%]",
         "english": "Minimum Throttle"
     },
     "govMinThrottleHelp": {


### PR DESCRIPTION
wrong Translation. English tells correct "Minimum", German was wrong translated to "Maximum" - now its Correct "Minimum"