### PR TITLE
Enable STM32 DFU driver installation task by default

### DIFF
--- a/assets/windows/installer.iss
+++ b/assets/windows/installer.iss
@@ -272,4 +272,4 @@ begin
 end;
 
 [Tasks]
-Name: "install_stm_dfu"; Description: "{cm:STDFUDriverTaskDesc}"; Flags: unchecked
+Name: "install_stm_dfu"; Description: "{cm:STDFUDriverTaskDesc}"


### PR DESCRIPTION
## PR: Enable STM32 DFU driver installation task by default

### Summary
This PR updates the Windows installer to enable the optional STM32 DFU driver installation task by default.

### Why
Most Windows users flashing Rotorflight firmware require the STM32 DFU driver for DFU mode detection and firmware flashing. Enabling the task by default improves first-time setup success while still allowing users to opt out if desired.

### Changes
- Sets the STM32 DFU driver installer task to checked by default
- Keeps STM32 DFU driver installation optional
- Keeps the STMicroelectronics license acceptance flow unchanged
- Leaves macOS/Linux installers unchanged

### Testing
Validated:
- STM32 DFU driver task is checked by default during Windows installation
- Users can still deselect the task before installation
- License page is still shown only when the task remains selected
- Driver installation and configurator launch behavior unchanged