### PR TITLE
Flasher, fix missing ignore items in target default configs

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -701,8 +701,10 @@ tab.initialize = function (callback) {
             /^feature [-]?TELEMETRY/i,
             /^resource PWM/i,
             /^resource MOTOR [5-8]/i,
+            /^resource OSD/i,
             /^serial [0-9]/i,
             /^set serialrx/i,
+            /^set max7456/i,
         ];
 
         function cleanUnifiedConfigFile(input) {


### PR DESCRIPTION
When flashing BF legacy targets , there are some target defaults not foltered out. Causes RED error messages with cli command "defaults" or "defaults nosave". 
Can be seen when restoring diff backup files etc. Example:

```
# defaults nosave
# resetting to defaults
###ERROR IN resource: INVALID RESOURCE NAME: 'OSD_CS'###
###ERROR IN set: INVALID NAME###
```
