### PR TITLE
Add Windows STM32 DFU driver detection and install warning

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -138,6 +138,10 @@ function helper_build_app_nwjs() {
   const tasks = [build_bundle(), build_app_nwjs];
 
   switch (context.target.platform) {
+    case "win":
+      tasks.push(build_nwjs_windows_driver_assets);
+      break;
+
     case "linux":
       tasks.push(build_nwjs_unix_permissions);
       tasks.push(build_nwjs_linux_assets);
@@ -183,6 +187,12 @@ function build_app_nwjs() {
 
 function build_nwjs_linux_assets() {
   return gulp.src("assets/linux/**").pipe(gulp.dest(context.appdir));
+}
+
+function build_nwjs_windows_driver_assets() {
+  return gulp
+    .src("assets/windows/drivers/**")
+    .pipe(gulp.dest(`${context.appdir}/drivers`));
 }
 
 /**

--- a/locales/bg/messages.json
+++ b/locales/bg/messages.json
@@ -5487,6 +5487,42 @@
         "message": "Моля, флашвайте <span class=\"message-negative\">САМО</span> хардуер <strong>Роторфлайт</strong> или <strong>Бетафлайт</strong> с този фърмуер флашър.<br /><br /><strong>Бележка: </strong>Зареждащата програма STM32 (bootloader) е записана в ROM и не може да бъде повредена безвъзвратно.<br /><strong>Бележка: </strong><span class=\"message-negative\">Авто-свързването</span> е винаги изключено, докато сте във фърмуер флашъра.<br /><strong>Бележка: </strong>Уверете се, че имате резервно копие; някои обновявания/връщания към по-стара версия ще изтрият конфигурацията.<br /><strong>Бележка:</strong> Ако имате проблеми с флашването, <strong>опитайте първо да изключите всички кабели от полетния контролер (FC)</strong>, рестартирайте, обновете драйверите.<br /><strong>Бележка:</strong> При флашване на платки с директно свързан USB конектор (повечето по-нови платки) се уверете, че сте прочели раздела за USB флашване в ръководството и че имате инсталиран правилния софтуер и драйвери",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Възстановяване / Загубена комуникация</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -5139,6 +5139,42 @@
         "message": "Bitte <span class=\"message-negative\">NUR</span> <strong>Rotorflight</strong> oder <strong>Betaflight</strong> Hardware mit diesem Konfigurator flashen.<br /><br /><strong>Hinweis: </strong> Der STM32 Bootloader ist im ROM gespeichert und kann nicht überschrieben werden.<br /><strong>Hinweis: </strong><span class=\"message-negative\">Auto-Connect</span> wird im Firmware-Flasher deaktiviert.<br /><strong>Hinweis: </strong> Unbedingt vor dem Firmware-Update ein Backup der Konfiguration anlegen. Bei manchen Updates wird die Konfiguration überschrieben.<br /><strong>Hinweis:</strong> Bei Problemen beim Flashen <strong>alle Komponenten vom Flight-Controller entfernen bzw. ablöten. </strong> Dann Neustart durchführen und Treiber updaten.",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Wiederherstellung / Abgebrochene Kommunikation</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4267,6 +4267,33 @@
     "firmwareFlasherWarningText": {
         "message": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Recovery / Lost communication</strong>"
     },
@@ -7743,7 +7770,7 @@
     "presetsButtonReview": {
         "message": "Review Selected Presets"
     },
-    "presetsButtonReviewCLI":{
+    "presetsButtonReviewCLI": {
         "message": "Review CLI"
     },
     "presetsButtonApply": {

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -5139,6 +5139,42 @@
         "message": "Por favor <span class=\"message-negative\">SÓLO</span> cargue <strong>Rotorflight</strong> o <strong>Betaflight</strong> hardware con este cargador de firmware.<br /><br /><strong>Nota: </strong>El STM32 bootloader se almacena en ROM, y no puede bloquearse.<br /><strong>Nota: </strong><span class=\"message-negative\">Auto-Conectar</span> está siempre deshabilitado mientras está usando el cargador de firmware.<br /><strong>Note: </strong>Asegúerese de tener un backup; algunas actualizaciones/downgrades borrarán su configuración.<br /><strong>Nota:</strong> Si tiene problemas cargandolo <strong>intente desconectar todos los cables de su FC</strong> primero, trate rearrancar, actualice drivers.<br /><strong>Nota:</strong> Cuando actualice placas que tengan conectados enchufes USB (la mayoría de las nuevas) asegúrese de que haya leído la sección USB Flashing del manual y que tiene el software y los drivers correctos instalados",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Recuperación / Pérdida de comunicación</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -5139,6 +5139,42 @@
         "message": "Veuillez faire <span class=\"message-negative\">UNIQUEMENT</span> flasher le matériel <strong>Rotorflight</strong> ou <strong>Betaflight</strong> avec ce flasheur de firmware.<br /><br /><strong>Remarque : </strong>Le chargeur de démarrage STM32 est stocké dans la ROM, il ne peut pas être intégré.<br /><strong>Remarque : </strong><span class=\"message-negative\">Connexion automatique </span> est toujours désactivé lorsque vous êtes dans le microprogramme flasher.<br /><strong>Remarque : </strong>Assurez-vous d'avoir une sauvegarde ; certaines mises à niveau/rétrogradations effaceront votre configuration.<br /><strong>Remarque :</strong> Si vous rencontrez des problèmes de flash, <strong>essayez d'abord de déconnecter tous les câbles de votre FC</strong>, essayez de redémarrer et mettez à niveau les pilotes.< br /><strong>Remarque :</strong> Lorsque vous flashez des cartes qui ont des prises USB directement connectées (la plupart des cartes les plus récentes), assurez-vous d'avoir lu la section Flashage USB du manuel et d'avoir installé le logiciel et les pilotes appropriés.",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Récupération / Communication coupée</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -6403,6 +6403,42 @@
             "english": "Please do <span class=\"message-negative\">not</span> try to flash <strong>non-Betaflight</strong> hardware with this firmware flasher.<br />Do <span class=\"message-negative\">not</span> <strong>disconnect</strong> the board or <strong>turn off</strong> your computer while flashing.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the Betaflight manual and have the correct software and drivers installed"
         }
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong> Recupero / comunicazione persa </strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -6403,6 +6403,42 @@
             "english": "Please do <span class=\"message-negative\">not</span> try to flash <strong>non-Betaflight</strong> hardware with this firmware flasher.<br />Do <span class=\"message-negative\">not</span> <strong>disconnect</strong> the board or <strong>turn off</strong> your computer while flashing.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the Betaflight manual and have the correct software and drivers installed"
         }
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>リカバリー / 通信ロスト</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -6403,6 +6403,42 @@
             "english": "Please do <span class=\"message-negative\">not</span> try to flash <strong>non-Betaflight</strong> hardware with this firmware flasher.<br />Do <span class=\"message-negative\">not</span> <strong>disconnect</strong> the board or <strong>turn off</strong> your computer while flashing.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the Betaflight manual and have the correct software and drivers installed"
         }
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>통신 복구 / 손실</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -5139,6 +5139,42 @@
         "message": "Flash <span class=\"message-negative\">ALLEEN</span> <strong>Rotorflight</strong> of <strong>Betaflight</strong> hardware met deze firmware flasher.<br /><br /><strong>Opmerking: </strong>De STM32 bootloader is opgeslagen in ROM, deze kan niet overschreven of beschadigd worden.<br /><strong>Opmerking: </strong><span class=\"message-negative\">Auto-Connect</span> is altijd uitgeschakeld terwijl firmware wordt geflashed.<br /><strong>Opmerking: </strong>Zorg ervoor dat je een back-up hebt; sommige upgrades/downgraden zullen je configuratie wissen.<br /><strong>Opmerking:</strong> Als je problemen hebt met het flashen <strong>probeer dan eerst alle kabels te verwijderen van je FC</strong>, probeer opnieuw op te starten en/of upgrade de drivers.<br /><strong>Opmerking:</strong> Als je bord een USB aansluiting heeft zorg er dan voor dat je de juiste software en drivers geïnstalleerd zijn",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Communicatie herstellen</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/pl/messages.json
+++ b/locales/pl/messages.json
@@ -6367,6 +6367,42 @@
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed",
         "status": "New entry. Please translate!"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Odzyskiwanie / Utracono komunikacje</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -6403,6 +6403,42 @@
             "english": "Please do <span class=\"message-negative\">not</span> try to flash <strong>non-Betaflight</strong> hardware with this firmware flasher.<br />Do <span class=\"message-negative\">not</span> <strong>disconnect</strong> the board or <strong>turn off</strong> your computer while flashing.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the Betaflight manual and have the correct software and drivers installed"
         }
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Recuperação / Comunicação perdida</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/pt_BR/messages.json
+++ b/locales/pt_BR/messages.json
@@ -6382,6 +6382,42 @@
             "english": "Please do <span class=\"message-negative\">not</span> try to flash <strong>non-Betaflight</strong> hardware with this firmware flasher.<br />Do <span class=\"message-negative\">not</span> <strong>disconnect</strong> the board or <strong>turn off</strong> your computer while flashing.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the Betaflight manual and have the correct software and drivers installed"
         }
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Recuperação / Comunicação perdida</strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/zh/messages.json
+++ b/locales/zh/messages.json
@@ -6407,6 +6407,42 @@
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed",
         "status": "New entry. Please translate!"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong>Recovery / Lost communication</strong>",
         "english": "<strong>Recovery / Lost communication</strong>",

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -5143,6 +5143,42 @@
         "message": "请<span class=\"message-negative\">仅使用</span>此固件刷写器刷写 <strong>Rotorflight</strong> 或 <strong>Betaflight</strong> 硬件。<br /><br /><strong>注意：</strong>STM32 引导加载程序存储在 ROM 中，不会出现变砖的情况。<br /><strong>注意：</strong> 在使用固件刷新程序时，自动连接（Auto-Connect）功能始终处于禁用状态。<br /><strong>注意：</strong>确保有备份；某些升级/降级会清除你的配置。<br /><strong>注意：</strong> 如果在刷写过程中遇到问题，请先断开 FC 上的所有电缆连接，尝试重启并升级驱动程序。<br /><strong>注意：</strong> 在刷写直接连接 USB 插座的电路板（大多数较新的电路板）时，确保已阅读手册中的 USB 刷写部分，并安装了正确的软件和驱动程序。",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong> 恢复/丢失通信 </strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/locales/zh_TW/messages.json
+++ b/locales/zh_TW/messages.json
@@ -5139,6 +5139,42 @@
         "message": "請<span class=\"message-negative\">僅使用</span>此韌體刷寫器刷寫 <strong>Rotorflight</strong> 或 <strong>Betaflight</strong> 硬體。<br /><br /><strong>注意：</strong>STM32 引導程式儲存在 ROM 中，不會出現變磚的情況。<br /><strong>注意：</strong> 在使用韌體刷新程式時，自動連接（Auto-Connect）功能始終處於關閉狀態。<br /><strong>注意：</strong>確保有備份；某些升級/降級會清除你的設定。<br /><strong>注意：</strong> 如果在刷寫過程中遇到問題，請先斷開 FC 上的所有電纜連接，嘗試重新啟動並升級驅動程式。<br /><strong>注意：</strong> 在刷寫直接連接 USB 插座的電路板（大多數較新的電路板）時，確保已閱讀手冊中的 USB 刷寫部分，並安裝了正確的軟體和驅動程式。",
         "english": "Please do <span class=\"message-negative\">ONLY</span> flash <strong>Rotorflight</strong> or <strong>Betaflight</strong> hardware with this firmware flasher.<br /><br /><strong>Note: </strong>STM32 bootloader is stored in ROM, it cannot be bricked.<br /><strong>Note: </strong><span class=\"message-negative\">Auto-Connect</span> is always disabled while you are inside firmware flasher.<br /><strong>Note: </strong>Make sure you have a backup; some upgrades/downgrades will wipe your configuration.<br /><strong>Note:</strong> If you have problems flashing <strong>try disconnecting all cables from your FC</strong> first, try rebooting, upgrade drivers.<br /><strong>Note:</strong> When flashing boards that have directly connected USB sockets (most newer boards) ensure you have read the USB Flashing section of the manual and have the correct software and drivers installed"
     },
+    "firmwareFlasherDfuDriverRequiredTitle": {
+        "message": "❌ STM32 DFU Driver Required",
+        "english": "❌ STM32 DFU Driver Required"
+    },
+    "firmwareFlasherDfuDriverRequiredText": {
+        "message": "The STM32 DFU driver is not installed.",
+        "english": "The STM32 DFU driver is not installed."
+    },
+    "firmwareFlasherDfuDriverRequiredWindowsText": {
+        "message": "Windows requires this driver before flashing boards in DFU mode.",
+        "english": "Windows requires this driver before flashing boards in DFU mode."
+    },
+    "firmwareFlasherInstallDfuDriver": {
+        "message": "Install STM32 DFU Driver",
+        "english": "Install STM32 DFU Driver"
+    },
+    "firmwareFlasherDfuDriverInstalling": {
+        "message": "Installing STM32 DFU driver...",
+        "english": "Installing STM32 DFU driver..."
+    },
+    "firmwareFlasherDfuDriverMissingLog": {
+        "message": "STM32 DFU driver is required before flashing firmware on Windows.",
+        "english": "STM32 DFU driver is required before flashing firmware on Windows."
+    },
+    "firmwareFlasherDfuDriverCheckFailed": {
+        "message": "STM32 DFU driver check failed: $1",
+        "english": "STM32 DFU driver check failed: $1"
+    },
+    "firmwareFlasherDfuDriverInstallFailed": {
+        "message": "STM32 DFU driver installation did not complete successfully.",
+        "english": "STM32 DFU driver installation did not complete successfully."
+    },
+    "firmwareFlasherDfuDriverInstallFailedWithError": {
+        "message": "STM32 DFU driver installation failed: $1",
+        "english": "STM32 DFU driver installation failed: $1"
+    },
     "firmwareFlasherRecoveryHead": {
         "message": "<strong> 恢復/遺失通信 </strong>",
         "english": "<strong>Recovery / Lost communication</strong>"

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -255,10 +255,16 @@
 }
 
 .tab-firmware_flasher .dfu-driver-install-row {
-    align-items: center;
+    align-items: flex-start;
     display: flex;
-    gap: 10px;
+    flex-direction: column;
+    gap: 6px;
     margin-top: 10px;
+}
+
+.tab-firmware_flasher .dfu-driver-install-status {
+    line-height: 18px;
+    overflow-wrap: anywhere;
 }
 
 .tab-firmware_flasher .dfu-driver-install-status.invalid {

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -245,3 +245,23 @@
 .tab-firmware_flasher .options-container .field + .field {
     border-top: 1px solid var(--color-border);
 }
+
+.tab-firmware_flasher .dfu-driver-warning {
+    border-color: #a62e32;
+}
+
+.tab-firmware_flasher .dfu-driver-warning .spacer p {
+    font-weight: bold;
+}
+
+.tab-firmware_flasher .dfu-driver-install-row {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.tab-firmware_flasher .dfu-driver-install-status.invalid {
+    color: #a62e32;
+    font-weight: bold;
+}

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -32,6 +32,52 @@ function execFile(file, args, options = {}) {
     });
 }
 
+function execCommand(command, options = {}) {
+    const childProcess = getNodeModule("child_process");
+    const execOptions = { windowsHide: true, ...options };
+
+    return new Promise((resolve, reject) => {
+        childProcess.exec(command, execOptions, (error, stdout, stderr) => {
+            if (error) {
+                error.stdout = stdout;
+                error.stderr = stderr;
+                reject(error);
+                return;
+            }
+
+            resolve({ stdout, stderr });
+        });
+    });
+}
+
+function quoteWindowsCommandArg(value) {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function getSystemExecutable(fileName) {
+    if (typeof process === "undefined") {
+        return fileName;
+    }
+
+    const systemRoot = process.env.SystemRoot ?? process.env.windir;
+    if (!systemRoot) {
+        return fileName;
+    }
+
+    const path = getNodeModule("path");
+    const systemDirectory = process.arch === "ia32" && process.env.PROCESSOR_ARCHITEW6432 ? "Sysnative" : "System32";
+    return path.join(systemRoot, systemDirectory, fileName);
+}
+
+function formatProcessError(error) {
+    const output = [error.stdout, error.stderr]
+        .filter((value) => value && value.trim())
+        .join("\n")
+        .trim();
+
+    return output || error.message;
+}
+
 function hasStm32DfuDriver(output) {
     return /stm32bootloader\.inf/i.test(output)
         || /stm32 bootloader/i.test(output)
@@ -39,13 +85,13 @@ function hasStm32DfuDriver(output) {
 }
 
 async function hasDriverPackage() {
-    const { stdout, stderr } = await execFile("pnputil.exe", ["/enum-drivers"]);
+    const { stdout, stderr } = await execFile(getSystemExecutable("pnputil.exe"), ["/enum-drivers"]);
     return hasStm32DfuDriver(`${stdout}\n${stderr}`);
 }
 
 async function hasInstalledDeviceDriver() {
     try {
-        const { stdout, stderr } = await execFile("pnputil.exe", ["/enum-devices", "/instanceid", STM32_DFU_DEVICE_ID]);
+        const { stdout, stderr } = await execFile(getSystemExecutable("pnputil.exe"), ["/enum-devices", "/instanceid", STM32_DFU_DEVICE_ID]);
         const output = `${stdout}\n${stderr}`;
         return /vid_0483&pid_df11/i.test(output) && (/winusb/i.test(output) || /stm32 bootloader/i.test(output));
     } catch (error) {
@@ -108,7 +154,23 @@ export async function installStm32DfuDriver() {
         throw new Error("STM32 DFU driver package was not found");
     }
 
-    await execFile("pnputil.exe", ["/add-driver", infPath, "/install"]);
+    const pnputilPath = getSystemExecutable("pnputil.exe");
+    const command = [
+        quoteWindowsCommandArg(pnputilPath),
+        "/add-driver",
+        quoteWindowsCommandArg(infPath),
+        "/install",
+    ].join(" ");
+
+    try {
+        await execCommand(command);
+    } catch (error) {
+        if (await isStm32DfuDriverInstalled()) {
+            return true;
+        }
+
+        throw new Error(formatProcessError(error), { cause: error });
+    }
 
     return isStm32DfuDriverInstalled();
 }

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -54,16 +54,6 @@ function getSystemExecutable(fileName) {
     return systemDirectory ? path.join(systemDirectory, fileName) : fileName;
 }
 
-function getPowerShellExecutable() {
-    const path = getNodeModule("path");
-    const systemDirectory = getSystemDirectory();
-    return systemDirectory ? path.join(systemDirectory, "WindowsPowerShell", "v1.0", "powershell.exe") : "powershell.exe";
-}
-
-function quotePowerShellString(value) {
-    return `'${String(value).replace(/'/g, "''")}'`;
-}
-
 function quoteWindowsCommandArg(value) {
     return `"${String(value).replace(/"/g, '\\"')}"`;
 }
@@ -126,49 +116,54 @@ async function runElevatedPnputilInstall(infPath) {
     const basePath = path.join(os.tmpdir(), `rotorflight-stm32-dfu-driver-${Date.now()}`);
     const outputPath = `${basePath}.log`;
     const exitCodePath = `${basePath}.exit`;
-    const scriptPath = `${basePath}.ps1`;
-    const launcherPath = `${basePath}.vbs`;
+    const batchPath = `${basePath}.cmd`;
+    const workerPath = `${basePath}.worker.vbs`;
+    const launcherPath = `${basePath}.launcher.vbs`;
+    const pnputilPath = getSystemExecutable("pnputil.exe");
+    const cmdPath = getSystemExecutable("cmd.exe");
+    const wscriptPath = getSystemExecutable("wscript.exe");
 
-    const installScript = [
-        "$ErrorActionPreference = 'Continue'",
-        `$pnputil = ${quotePowerShellString(getSystemExecutable("pnputil.exe"))}`,
-        `$inf = ${quotePowerShellString(infPath)}`,
-        `$outputPath = ${quotePowerShellString(outputPath)}`,
-        `$exitCodePath = ${quotePowerShellString(exitCodePath)}`,
-        "$code = 1",
-        "try {",
-        "    & $pnputil /add-driver $inf /install *> $outputPath",
-        "    $code = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 }",
-        "    & $pnputil /scan-devices *>> $outputPath",
-        "} catch {",
-        "    $_ | Out-String | Add-Content -LiteralPath $outputPath",
-        "} finally {",
-        "    Set-Content -LiteralPath $exitCodePath -Value $code -Encoding ASCII",
-        "}",
-        "exit $code",
+    const installBatch = [
+        "@echo off",
+        [
+            quoteWindowsCommandArg(pnputilPath),
+            "/add-driver",
+            quoteWindowsCommandArg(infPath),
+            "/install",
+            ">",
+            quoteWindowsCommandArg(outputPath),
+            "2>&1",
+        ].join(" "),
+        "set code=%ERRORLEVEL%",
+        [
+            quoteWindowsCommandArg(pnputilPath),
+            "/scan-devices",
+            ">>",
+            quoteWindowsCommandArg(outputPath),
+            "2>&1",
+        ].join(" "),
+        `> ${quoteWindowsCommandArg(exitCodePath)} echo %code%`,
+        "exit /b %code%",
     ].join("\r\n");
 
-    const powerShellArgs = [
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-WindowStyle",
-        "Hidden",
-        "-File",
-        quoteWindowsCommandArg(scriptPath),
-    ].join(" ");
+    const workerScript = [
+        "Set shell = CreateObject(\"WScript.Shell\")",
+        `code = shell.Run(${quoteVbsString(`${quoteWindowsCommandArg(cmdPath)} /d /c ${quoteWindowsCommandArg(batchPath)}`)}, 0, True)`,
+        "WScript.Quit code",
+    ].join("\r\n");
 
     const launcherScript = [
         "Set shell = CreateObject(\"Shell.Application\")",
-        `shell.ShellExecute ${quoteVbsString(getPowerShellExecutable())}, ${quoteVbsString(powerShellArgs)}, "", "runas", 0`,
+        `shell.ShellExecute ${quoteVbsString(wscriptPath)}, ${quoteVbsString(`//B ${quoteWindowsCommandArg(workerPath)}`)}, "", "runas", 0`,
     ].join("\r\n");
 
-    writeTextFile(scriptPath, installScript);
+    writeTextFile(batchPath, installBatch);
+    writeTextFile(workerPath, workerScript);
     writeTextFile(launcherPath, launcherScript);
 
     let launchError;
     try {
-        await execFile(getSystemExecutable("wscript.exe"), ["//B", launcherPath]);
+        await execFile(wscriptPath, ["//B", launcherPath]);
     } catch (error) {
         launchError = error;
     }
@@ -180,7 +175,8 @@ async function runElevatedPnputilInstall(infPath) {
 
     removeFileIfExists(outputPath);
     removeFileIfExists(exitCodePath);
-    removeFileIfExists(scriptPath);
+    removeFileIfExists(batchPath);
+    removeFileIfExists(workerPath);
     removeFileIfExists(launcherPath);
 
     if (!completed && !launchError) {

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -60,13 +60,16 @@ function getPowerShellExecutable() {
     return systemDirectory ? path.join(systemDirectory, "WindowsPowerShell", "v1.0", "powershell.exe") : "powershell.exe";
 }
 
-function encodePowerShellCommand(command) {
-    const buffer = getNodeModule("buffer").Buffer;
-    return buffer.from(command, "utf16le").toString("base64");
-}
-
 function quotePowerShellString(value) {
     return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function quoteWindowsCommandArg(value) {
+    return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+function quoteVbsString(value) {
+    return `"${String(value).replace(/"/g, '""')}"`;
 }
 
 function formatProcessError(error) {
@@ -87,6 +90,27 @@ function readFileIfExists(path) {
     }
 }
 
+function writeTextFile(path, contents) {
+    const fs = getNodeModule("fs");
+    fs.writeFileSync(path, contents, "utf8");
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFile(path, timeoutMs) {
+    const fs = getNodeModule("fs");
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < timeoutMs) {
+        if (fs.existsSync(path)) {
+            return true;
+        }
+        await sleep(500);
+    }
+    return false;
+}
+
 function removeFileIfExists(path) {
     const fs = getNodeModule("fs");
     try {
@@ -102,50 +126,69 @@ async function runElevatedPnputilInstall(infPath) {
     const basePath = path.join(os.tmpdir(), `rotorflight-stm32-dfu-driver-${Date.now()}`);
     const outputPath = `${basePath}.log`;
     const exitCodePath = `${basePath}.exit`;
+    const scriptPath = `${basePath}.ps1`;
+    const launcherPath = `${basePath}.vbs`;
 
-    const innerCommand = [
-        "$ErrorActionPreference = 'Continue';",
-        `$pnputil = ${quotePowerShellString(getSystemExecutable("pnputil.exe"))};`,
-        `$inf = ${quotePowerShellString(infPath)};`,
-        `$outputPath = ${quotePowerShellString(outputPath)};`,
-        `$exitCodePath = ${quotePowerShellString(exitCodePath)};`,
-        "& $pnputil /add-driver $inf /install *> $outputPath;",
-        "$code = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 };",
-        "& $pnputil /scan-devices *>> $outputPath;",
-        "Set-Content -LiteralPath $exitCodePath -Value $code -Encoding ASCII;",
-        "exit $code;",
+    const installScript = [
+        "$ErrorActionPreference = 'Continue'",
+        `$pnputil = ${quotePowerShellString(getSystemExecutable("pnputil.exe"))}`,
+        `$inf = ${quotePowerShellString(infPath)}`,
+        `$outputPath = ${quotePowerShellString(outputPath)}`,
+        `$exitCodePath = ${quotePowerShellString(exitCodePath)}`,
+        "$code = 1",
+        "try {",
+        "    & $pnputil /add-driver $inf /install *> $outputPath",
+        "    $code = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 }",
+        "    & $pnputil /scan-devices *>> $outputPath",
+        "} catch {",
+        "    $_ | Out-String | Add-Content -LiteralPath $outputPath",
+        "} finally {",
+        "    Set-Content -LiteralPath $exitCodePath -Value $code -Encoding ASCII",
+        "}",
+        "exit $code",
+    ].join("\r\n");
+
+    const powerShellArgs = [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-WindowStyle",
+        "Hidden",
+        "-File",
+        quoteWindowsCommandArg(scriptPath),
     ].join(" ");
 
-    const outerCommand = [
-        "$ErrorActionPreference = 'Stop';",
-        `$powerShell = ${quotePowerShellString(getPowerShellExecutable())};`,
-        `$encodedCommand = ${quotePowerShellString(encodePowerShellCommand(innerCommand))};`,
-        "$process = Start-Process -FilePath $powerShell -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-WindowStyle', 'Hidden', '-EncodedCommand', $encodedCommand) -Verb RunAs -WindowStyle Hidden -Wait -PassThru;",
-        "if ($null -eq $process) { exit 1 };",
-        "exit $process.ExitCode;",
-    ].join(" ");
+    const launcherScript = [
+        "Set shell = CreateObject(\"Shell.Application\")",
+        `shell.ShellExecute ${quoteVbsString(getPowerShellExecutable())}, ${quoteVbsString(powerShellArgs)}, "", "runas", 0`,
+    ].join("\r\n");
+
+    writeTextFile(scriptPath, installScript);
+    writeTextFile(launcherPath, launcherScript);
 
     let launchError;
     try {
-        await execFile(getPowerShellExecutable(), [
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-WindowStyle",
-            "Hidden",
-            "-EncodedCommand",
-            encodePowerShellCommand(outerCommand),
-        ]);
+        await execFile(getSystemExecutable("wscript.exe"), ["//B", launcherPath]);
     } catch (error) {
         launchError = error;
     }
 
+    const completed = await waitForFile(exitCodePath, 300000);
     const output = readFileIfExists(outputPath).trim();
     const exitCodeText = readFileIfExists(exitCodePath).trim();
     const exitCode = exitCodeText ? Number.parseInt(exitCodeText, 10) : launchError?.code;
 
     removeFileIfExists(outputPath);
     removeFileIfExists(exitCodePath);
+    removeFileIfExists(scriptPath);
+    removeFileIfExists(launcherPath);
+
+    if (!completed && !launchError) {
+        return {
+            exitCode: 1,
+            output: "STM32 DFU driver installation timed out or administrator permission was cancelled.",
+        };
+    }
 
     if (launchError && !Number.isFinite(exitCode)) {
         throw new Error(formatProcessError(launchError), { cause: launchError });

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -16,9 +16,10 @@ function getNodeModule(name) {
 
 function execFile(file, args, options = {}) {
     const childProcess = getNodeModule("child_process");
+    const execOptions = { windowsHide: true, ...options };
 
     return new Promise((resolve, reject) => {
-        childProcess.execFile(file, args, options, (error, stdout, stderr) => {
+        childProcess.execFile(file, args, execOptions, (error, stdout, stderr) => {
             if (error) {
                 error.stdout = stdout;
                 error.stderr = stderr;
@@ -97,15 +98,6 @@ export function findStm32DfuDriverInf() {
     return candidates.find(pathExists);
 }
 
-function encodePowerShellCommand(command) {
-    const buffer = getNodeModule("buffer").Buffer;
-    return buffer.from(command, "utf16le").toString("base64");
-}
-
-function escapePowerShellString(value) {
-    return value.replace(/`/g, "``").replace(/"/g, "`\"");
-}
-
 export async function installStm32DfuDriver() {
     if (GUI.operating_system !== "Windows") {
         return true;
@@ -116,21 +108,7 @@ export async function installStm32DfuDriver() {
         throw new Error("STM32 DFU driver package was not found");
     }
 
-    const command = [
-        "$process = Start-Process -FilePath \"pnputil.exe\"",
-        `-ArgumentList @("/add-driver", "${escapePowerShellString(infPath)}", "/install")`,
-        "-Verb RunAs -Wait -PassThru;",
-        "if ($null -eq $process) { exit 1 };",
-        "exit $process.ExitCode;",
-    ].join(" ");
-
-    await execFile("powershell.exe", [
-        "-NoProfile",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-EncodedCommand",
-        encodePowerShellCommand(command),
-    ], { windowsHide: false });
+    await execFile("pnputil.exe", ["/add-driver", infPath, "/install"]);
 
     return isStm32DfuDriverInstalled();
 }

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -1,0 +1,136 @@
+const STM32_DFU_DEVICE_ID = "USB\\VID_0483&PID_DF11";
+const STM32_DFU_INF_NAME = "STM32Bootloader.inf";
+
+function getNodeRequire() {
+    return globalThis.nw?.require ?? globalThis.require;
+}
+
+function getNodeModule(name) {
+    const nodeRequire = getNodeRequire();
+    if (!nodeRequire) {
+        throw new Error("Node.js integration is not available");
+    }
+
+    return nodeRequire(name);
+}
+
+function execFile(file, args, options = {}) {
+    const childProcess = getNodeModule("child_process");
+
+    return new Promise((resolve, reject) => {
+        childProcess.execFile(file, args, options, (error, stdout, stderr) => {
+            if (error) {
+                error.stdout = stdout;
+                error.stderr = stderr;
+                reject(error);
+                return;
+            }
+
+            resolve({ stdout, stderr });
+        });
+    });
+}
+
+function hasStm32DfuDriver(output) {
+    return /stm32bootloader\.inf/i.test(output)
+        || /stm32 bootloader/i.test(output)
+        || /vid_0483&pid_df11/i.test(output);
+}
+
+async function hasDriverPackage() {
+    const { stdout, stderr } = await execFile("pnputil.exe", ["/enum-drivers"]);
+    return hasStm32DfuDriver(`${stdout}\n${stderr}`);
+}
+
+async function hasInstalledDeviceDriver() {
+    try {
+        const { stdout, stderr } = await execFile("pnputil.exe", ["/enum-devices", "/instanceid", STM32_DFU_DEVICE_ID]);
+        const output = `${stdout}\n${stderr}`;
+        return /vid_0483&pid_df11/i.test(output) && (/winusb/i.test(output) || /stm32 bootloader/i.test(output));
+    } catch (error) {
+        const output = `${error.stdout ?? ""}\n${error.stderr ?? ""}`;
+        return /vid_0483&pid_df11/i.test(output) && (/winusb/i.test(output) || /stm32 bootloader/i.test(output));
+    }
+}
+
+export async function isStm32DfuDriverInstalled() {
+    if (GUI.operating_system !== "Windows") {
+        return true;
+    }
+
+    if (await hasDriverPackage()) {
+        return true;
+    }
+
+    return hasInstalledDeviceDriver();
+}
+
+function pathExists(path) {
+    const fs = getNodeModule("fs");
+    return fs.existsSync(path);
+}
+
+function getAppDirectory() {
+    if (typeof process === "undefined") {
+        return undefined;
+    }
+
+    return process.cwd();
+}
+
+function getExecutableDirectory(path) {
+    if (typeof process === "undefined" || !process.execPath) {
+        return undefined;
+    }
+
+    return path.dirname(process.execPath);
+}
+
+export function findStm32DfuDriverInf() {
+    const path = getNodeModule("path");
+    const candidates = [
+        path.join(getAppDirectory() ?? "", "assets", "windows", "drivers", "stm32", STM32_DFU_INF_NAME),
+        path.join(getAppDirectory() ?? "", "drivers", "stm32", STM32_DFU_INF_NAME),
+        path.join(getExecutableDirectory(path) ?? "", "drivers", "stm32", STM32_DFU_INF_NAME),
+    ];
+
+    return candidates.find(pathExists);
+}
+
+function encodePowerShellCommand(command) {
+    const buffer = getNodeModule("buffer").Buffer;
+    return buffer.from(command, "utf16le").toString("base64");
+}
+
+function escapePowerShellString(value) {
+    return value.replace(/`/g, "``").replace(/"/g, "`\"");
+}
+
+export async function installStm32DfuDriver() {
+    if (GUI.operating_system !== "Windows") {
+        return true;
+    }
+
+    const infPath = findStm32DfuDriverInf();
+    if (!infPath) {
+        throw new Error("STM32 DFU driver package was not found");
+    }
+
+    const command = [
+        "$process = Start-Process -FilePath \"pnputil.exe\"",
+        `-ArgumentList @("/add-driver", "${escapePowerShellString(infPath)}", "/install")`,
+        "-Verb RunAs -Wait -PassThru;",
+        "if ($null -eq $process) { exit 1 };",
+        "exit $process.ExitCode;",
+    ].join(" ");
+
+    await execFile("powershell.exe", [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-EncodedCommand",
+        encodePowerShellCommand(command),
+    ], { windowsHide: false });
+
+    return isStm32DfuDriverInstalled();
+}

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -32,41 +32,41 @@ function execFile(file, args, options = {}) {
     });
 }
 
-function execCommand(command, options = {}) {
-    const childProcess = getNodeModule("child_process");
-    const execOptions = { windowsHide: true, ...options };
 
-    return new Promise((resolve, reject) => {
-        childProcess.exec(command, execOptions, (error, stdout, stderr) => {
-            if (error) {
-                error.stdout = stdout;
-                error.stderr = stderr;
-                reject(error);
-                return;
-            }
-
-            resolve({ stdout, stderr });
-        });
-    });
-}
-
-function quoteWindowsCommandArg(value) {
-    return `"${String(value).replace(/"/g, '\\"')}"`;
-}
-
-function getSystemExecutable(fileName) {
+function getSystemDirectory() {
     if (typeof process === "undefined") {
-        return fileName;
+        return undefined;
     }
 
     const systemRoot = process.env.SystemRoot ?? process.env.windir;
     if (!systemRoot) {
-        return fileName;
+        return undefined;
     }
 
     const path = getNodeModule("path");
     const systemDirectory = process.arch === "ia32" && process.env.PROCESSOR_ARCHITEW6432 ? "Sysnative" : "System32";
-    return path.join(systemRoot, systemDirectory, fileName);
+    return path.join(systemRoot, systemDirectory);
+}
+
+function getSystemExecutable(fileName) {
+    const path = getNodeModule("path");
+    const systemDirectory = getSystemDirectory();
+    return systemDirectory ? path.join(systemDirectory, fileName) : fileName;
+}
+
+function getPowerShellExecutable() {
+    const path = getNodeModule("path");
+    const systemDirectory = getSystemDirectory();
+    return systemDirectory ? path.join(systemDirectory, "WindowsPowerShell", "v1.0", "powershell.exe") : "powershell.exe";
+}
+
+function encodePowerShellCommand(command) {
+    const buffer = getNodeModule("buffer").Buffer;
+    return buffer.from(command, "utf16le").toString("base64");
+}
+
+function quotePowerShellString(value) {
+    return `'${String(value).replace(/'/g, "''")}'`;
 }
 
 function formatProcessError(error) {
@@ -76,6 +76,84 @@ function formatProcessError(error) {
         .trim();
 
     return output || error.message;
+}
+
+function readFileIfExists(path) {
+    const fs = getNodeModule("fs");
+    try {
+        return fs.readFileSync(path, "utf8");
+    } catch {
+        return "";
+    }
+}
+
+function removeFileIfExists(path) {
+    const fs = getNodeModule("fs");
+    try {
+        fs.unlinkSync(path);
+    } catch {
+        // Ignore cleanup failures for temporary install logs.
+    }
+}
+
+async function runElevatedPnputilInstall(infPath) {
+    const os = getNodeModule("os");
+    const path = getNodeModule("path");
+    const basePath = path.join(os.tmpdir(), `rotorflight-stm32-dfu-driver-${Date.now()}`);
+    const outputPath = `${basePath}.log`;
+    const exitCodePath = `${basePath}.exit`;
+
+    const innerCommand = [
+        "$ErrorActionPreference = 'Continue';",
+        `$pnputil = ${quotePowerShellString(getSystemExecutable("pnputil.exe"))};`,
+        `$inf = ${quotePowerShellString(infPath)};`,
+        `$outputPath = ${quotePowerShellString(outputPath)};`,
+        `$exitCodePath = ${quotePowerShellString(exitCodePath)};`,
+        "& $pnputil /add-driver $inf /install *> $outputPath;",
+        "$code = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 };",
+        "Set-Content -LiteralPath $exitCodePath -Value $code -Encoding ASCII;",
+        "exit $code;",
+    ].join(" ");
+
+    const outerCommand = [
+        "$ErrorActionPreference = 'Stop';",
+        `$powerShell = ${quotePowerShellString(getPowerShellExecutable())};`,
+        `$encodedCommand = ${quotePowerShellString(encodePowerShellCommand(innerCommand))};`,
+        "$process = Start-Process -FilePath $powerShell -ArgumentList @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-WindowStyle', 'Hidden', '-EncodedCommand', $encodedCommand) -Verb RunAs -WindowStyle Hidden -Wait -PassThru;",
+        "if ($null -eq $process) { exit 1 };",
+        "exit $process.ExitCode;",
+    ].join(" ");
+
+    let launchError;
+    try {
+        await execFile(getPowerShellExecutable(), [
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-WindowStyle",
+            "Hidden",
+            "-EncodedCommand",
+            encodePowerShellCommand(outerCommand),
+        ]);
+    } catch (error) {
+        launchError = error;
+    }
+
+    const output = readFileIfExists(outputPath).trim();
+    const exitCodeText = readFileIfExists(exitCodePath).trim();
+    const exitCode = exitCodeText ? Number.parseInt(exitCodeText, 10) : launchError?.code;
+
+    removeFileIfExists(outputPath);
+    removeFileIfExists(exitCodePath);
+
+    if (launchError && !Number.isFinite(exitCode)) {
+        throw new Error(formatProcessError(launchError), { cause: launchError });
+    }
+
+    return {
+        exitCode: Number.isFinite(exitCode) ? exitCode : 1,
+        output: output || (launchError ? formatProcessError(launchError) : ""),
+    };
 }
 
 function hasStm32DfuDriver(output) {
@@ -154,23 +232,14 @@ export async function installStm32DfuDriver() {
         throw new Error("STM32 DFU driver package was not found");
     }
 
-    const pnputilPath = getSystemExecutable("pnputil.exe");
-    const command = [
-        quoteWindowsCommandArg(pnputilPath),
-        "/add-driver",
-        quoteWindowsCommandArg(infPath),
-        "/install",
-    ].join(" ");
-
-    try {
-        await execCommand(command);
-    } catch (error) {
-        if (await isStm32DfuDriverInstalled()) {
-            return true;
-        }
-
-        throw new Error(formatProcessError(error), { cause: error });
+    const result = await runElevatedPnputilInstall(infPath);
+    if (result.exitCode === 0) {
+        return isStm32DfuDriverInstalled();
     }
 
-    return isStm32DfuDriverInstalled();
+    if (await isStm32DfuDriverInstalled()) {
+        return true;
+    }
+
+    throw new Error(result.output || `pnputil exited with code ${result.exitCode}`);
 }

--- a/src/js/dfu_driver.js
+++ b/src/js/dfu_driver.js
@@ -111,6 +111,7 @@ async function runElevatedPnputilInstall(infPath) {
         `$exitCodePath = ${quotePowerShellString(exitCodePath)};`,
         "& $pnputil /add-driver $inf /install *> $outputPath;",
         "$code = if ($null -ne $LASTEXITCODE) { $LASTEXITCODE } else { 1 };",
+        "& $pnputil /scan-devices *>> $outputPath;",
         "Set-Content -LiteralPath $exitCodePath -Value $code -Encoding ASCII;",
         "exit $code;",
     ].join(" ");

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -6,6 +6,7 @@ import { readTextFile, writeTextFile } from '@/js/filesystem.js';
 import * as github from '@/js/GitHubApi.js';
 import { ReleaseChecker } from '@/js/release_checker.js';
 import { manufacturers } from "@/js/manufacturers.js";
+import { installStm32DfuDriver, isStm32DfuDriverInstalled } from "@/js/dfu_driver.js";
 
 async function getCachedUnifiedTargets() {
   const { unifiedSourceCache } = await new Promise((resolve) => chrome.storage.local.get("unifiedSourceCache", resolve));
@@ -29,6 +30,7 @@ const tab = {
     unifiedTarget: {}, // the Unified Target configuration to be spliced into the configuration
     isConfigLocal: false, // Set to true if the user loads one locally
     boardDetectionInProgress: false,
+    dfuDriverFlashBlocked: false,
 };
 
 tab.initialize = function (callback) {
@@ -39,6 +41,7 @@ tab.initialize = function (callback) {
     self.isConfigLocal = false;
     self.intel_hex = undefined;
     self.parsed_hex = undefined;
+    self.dfuDriverFlashBlocked = false;
 
 
     function onFirmwareCacheUpdate(release) {
@@ -733,6 +736,74 @@ tab.initialize = function (callback) {
             return output;
         }
 
+
+        function setDfuDriverInstallStatus(message, isError = false) {
+            const statusElement = $('.dfu-driver-install-status');
+            statusElement.text(message ?? '');
+            statusElement.toggleClass('invalid', isError);
+        }
+
+        function showDfuDriverWarning(show) {
+            $('.dfu-driver-warning').prop('hidden', !show).toggle(show);
+            self.dfuDriverFlashBlocked = show;
+            if (show) {
+                self.enableFlashing(false);
+            } else if (self.parsed_hex) {
+                self.enableFlashing(true);
+            }
+        }
+
+        async function checkDfuDriverRequirement() {
+            if (GUI.operating_system !== 'Windows') {
+                showDfuDriverWarning(false);
+                return;
+            }
+
+            try {
+                const installed = await isStm32DfuDriverInstalled();
+                showDfuDriverWarning(!installed);
+                if (!installed) {
+                    GUI.log(i18n.getMessage('firmwareFlasherDfuDriverMissingLog'));
+                }
+            } catch (error) {
+                console.log(`STM32 DFU driver check failed: ${error.message}`);
+                GUI.log(i18n.getMessage('firmwareFlasherDfuDriverCheckFailed', [error.message]));
+                showDfuDriverWarning(true);
+                setDfuDriverInstallStatus(i18n.getMessage('firmwareFlasherDfuDriverCheckFailed', [error.message]), true);
+            }
+        }
+
+        async function installDfuDriver() {
+            const installButton = $('a.install_dfu_driver');
+            if (installButton.hasClass('disabled')) {
+                return;
+            }
+
+            installButton.addClass('disabled');
+            setDfuDriverInstallStatus(i18n.getMessage('firmwareFlasherDfuDriverInstalling'));
+
+            try {
+                const installed = await installStm32DfuDriver();
+                await checkDfuDriverRequirement();
+                if (installed && !self.dfuDriverFlashBlocked) {
+                    setDfuDriverInstallStatus();
+                } else {
+                    const message = i18n.getMessage('firmwareFlasherDfuDriverInstallFailed');
+                    console.log(message);
+                    GUI.log(message);
+                    setDfuDriverInstallStatus(message, true);
+                }
+            } catch (error) {
+                const message = i18n.getMessage('firmwareFlasherDfuDriverInstallFailedWithError', [error.message]);
+                console.log(message);
+                GUI.log(message);
+                setDfuDriverInstallStatus(message, true);
+                showDfuDriverWarning(true);
+            } finally {
+                installButton.removeClass('disabled');
+            }
+        }
+
         const portPickerElement = $('div#port-picker #port');
         function flashFirmware(firmware) {
             const options = {
@@ -778,7 +849,14 @@ tab.initialize = function (callback) {
             buildType_e.val(result.selected_build_type || 0).trigger('change');
         });
 
+        checkDfuDriverRequirement();
+
         // UI Hooks
+        $('a.install_dfu_driver').on('click', function (event) {
+            event.preventDefault();
+            installDfuDriver();
+        });
+
         $('a.load_file').on('click', async function () {
             self.enableFlashing(false);
 
@@ -1061,6 +1139,11 @@ tab.initialize = function (callback) {
         });
 
         function startFlashing() {
+            if (self.dfuDriverFlashBlocked) {
+                GUI.log(i18n.getMessage('firmwareFlasherDfuDriverMissingLog'));
+                return;
+            }
+
             exitDfuElement.addClass('disabled');
             $("a.load_remote_file").addClass('disabled');
             $("a.load_file").addClass('disabled');
@@ -1128,7 +1211,7 @@ tab.cleanup = function (callback) {
 };
 
 tab.enableFlashing = function (enabled) {
-    if (enabled) {
+    if (enabled && !this.dfuDriverFlashBlocked) {
         $('a.flash_firmware').removeClass('disabled');
     } else {
         $('a.flash_firmware').addClass('disabled');

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -773,6 +773,18 @@ tab.initialize = function (callback) {
             }
         }
 
+        function refreshDfuDeviceDiscoveryAfterDriverInstall() {
+            PortHandler.check_usb_devices();
+            PortHandler.check_serial_devices();
+
+            [1000, 2500, 5000].forEach((timeout, index) => {
+                GUI.timeout_add(`dfu_driver_refresh_${index}`, function () {
+                    PortHandler.check_usb_devices();
+                    PortHandler.check_serial_devices();
+                }, timeout);
+            });
+        }
+
         async function installDfuDriver() {
             const installButton = $('a.install_dfu_driver');
             if (installButton.hasClass('disabled')) {
@@ -784,6 +796,7 @@ tab.initialize = function (callback) {
 
             try {
                 const installed = await installStm32DfuDriver();
+                refreshDfuDeviceDiscoveryAfterDriverInstall();
                 await checkDfuDriverRequirement();
                 if (installed && !self.dfuDriverFlashBlocked) {
                     setDfuDriverInstallStatus();

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -107,6 +107,23 @@
                 <p i18n="firmwareFlasherTargetWarning"></p>
             </div>
         </div>
+        <div class="gui_box gui_warning dfu-driver-warning" hidden>
+            <div class="gui_box_titlebar">
+                <div class="spacer_box_title" style="text-align: center;"
+                    i18n="firmwareFlasherDfuDriverRequiredTitle">
+                </div>
+            </div>
+            <div class="spacer" style="margin-bottom: 10px;">
+                <p i18n="firmwareFlasherDfuDriverRequiredText"></p>
+                <p i18n="firmwareFlasherDfuDriverRequiredWindowsText"></p>
+                <div class="dfu-driver-install-row">
+                    <span class="default_btn">
+                        <a class="install_dfu_driver" href="#" i18n="firmwareFlasherInstallDfuDriver"></a>
+                    </span>
+                    <span class="dfu-driver-install-status"></span>
+                </div>
+            </div>
+        </div>
         <div class="gui_box gui_note">
             <div class="gui_box_titlebar">
                 <div class="spacer_box_title" style="text-align: center;"

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -48,6 +48,23 @@
                 </div>
             </div>
         </div>
+        <div class="gui_box gui_warning dfu-driver-warning" hidden>
+            <div class="gui_box_titlebar">
+                <div class="spacer_box_title" style="text-align: center;"
+                    i18n="firmwareFlasherDfuDriverRequiredTitle">
+                </div>
+            </div>
+            <div class="spacer" style="margin-bottom: 10px;">
+                <p i18n="firmwareFlasherDfuDriverRequiredText"></p>
+                <p i18n="firmwareFlasherDfuDriverRequiredWindowsText"></p>
+                <div class="dfu-driver-install-row">
+                    <span class="default_btn">
+                        <a class="install_dfu_driver" href="#" i18n="firmwareFlasherInstallDfuDriver"></a>
+                    </span>
+                    <span class="dfu-driver-install-status"></span>
+                </div>
+            </div>
+        </div>
         <div class="clear-both"></div>
         <div class="git_info">
             <div class="title" i18n="firmwareFlasherGithubInfoHead"></div>
@@ -105,23 +122,6 @@
                 <p i18n="firmwareFlasherWarningText"></p>
                 <br />
                 <p i18n="firmwareFlasherTargetWarning"></p>
-            </div>
-        </div>
-        <div class="gui_box gui_warning dfu-driver-warning" hidden>
-            <div class="gui_box_titlebar">
-                <div class="spacer_box_title" style="text-align: center;"
-                    i18n="firmwareFlasherDfuDriverRequiredTitle">
-                </div>
-            </div>
-            <div class="spacer" style="margin-bottom: 10px;">
-                <p i18n="firmwareFlasherDfuDriverRequiredText"></p>
-                <p i18n="firmwareFlasherDfuDriverRequiredWindowsText"></p>
-                <div class="dfu-driver-install-row">
-                    <span class="default_btn">
-                        <a class="install_dfu_driver" href="#" i18n="firmwareFlasherInstallDfuDriver"></a>
-                    </span>
-                    <span class="dfu-driver-install-status"></span>
-                </div>
             </div>
         </div>
         <div class="gui_box gui_note">


### PR DESCRIPTION
# Add Windows STM32 DFU driver detection and install warning

## Summary

This PR adds a Windows-only STM32 DFU driver detection check to the Firmware Flasher tab.

When Rotorflight Configurator is running on Windows and the required STM32 DFU driver is not detected, the Firmware Flasher tab now shows a clear warning with an install button so the user can quickly fix the issue.

The warning is hidden automatically when the driver is installed correctly. It is also hidden completely on Linux and macOS.

## Goal

Reduce confusion for Windows users who cannot flash firmware because the STM32 DFU driver is missing or not installed correctly.

Instead of failing silently or requiring the user to troubleshoot manually, Configurator now gives an obvious warning and a direct way to install the required driver.

## Behavior

- Shows the STM32 DFU driver warning **only on Windows**
- Hides the warning on **Linux and macOS**
- Hides the warning when the STM32 DFU driver is already installed
- Shows a clear warning when the driver is missing
- Provides an install button to quickly install the driver
- Re-checks the driver status after installation
- Automatically hides the warning once the issue is fixed

## User-facing change

Windows users without the required STM32 DFU driver will see a visible warning in the Firmware Flasher tab explaining that the driver is required for DFU flashing.

They can click the install button to install the driver, and once the driver is detected, the warning disappears.

## Why this is needed

DFU flashing on Windows depends on the correct STM32 DFU driver being installed. When the driver is missing, users may not understand why DFU flashing does not work.

This change makes the issue visible, actionable, and easy to resolve from inside Configurator.

## Testing

Tested expected behavior for:

- Windows with STM32 DFU driver missing
- Windows after installing the STM32 DFU driver
- Non-Windows platforms where the warning should remain hidden
- Firmware Flasher tab load/refresh behavior
- Warning visibility after driver status changes

## Notes

This change is intended to be non-intrusive.

Users who already have the required driver installed will not see any additional warning or UI.

Linux and macOS users are unaffected.