### PR TITLE
Add FBUS/S.Port Sensors diagnostic tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
                     <li class="tab_beepers"><a href="#" i18n="tabBeepers" class="tabicon ic_beepers" i18n_title="tabBeepers"></a></li>
                     <li class="tab_gps"><a href="#" i18n="tabGPS" class="tabicon ic_gps" i18n_title="tabGPS"></a></li>
                     <li class="tab_sensors"><a href="#" i18n="tabRawSensorData" class="tabicon ic_sensors" i18n_title="tabRawSensorData"></a></li>
+                    <li class="tab_fbus_sensors"><a href="#" i18n="tabFbusSensors" class="tabicon ic_sensors" i18n_title="tabFbusSensors"></a></li>
                     <li class="tab_blackbox"><a href="#" i18n="tabBlackbox" class="tabicon ic_data" i18n_title="tabBlackbox"></a></li>
                     <!-- spare icons
                     <li class=""><a href="#"class="tabicon ic_mission">Mission (spare icon)</a></li>

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -483,6 +483,48 @@
     "tabBlackbox": {
         "message": "Blackbox"
     },
+    "tabFbusSensors": {
+        "message": "FBUS/S.Port Sensors"
+    },
+    "fbusSensorsDescription": {
+        "message": "Sensors observed on the FBUS/S.Port bus while this board is acting as an FBUS or S.Port master."
+    },
+    "fbusSensorsEmpty": {
+        "message": "No FBUS/S.Port sensors observed yet"
+    },
+    "fbusSensorsNotSupported": {
+        "message": "This firmware does not support the FBUS/S.Port Sensors diagnostic."
+    },
+    "fbusSensorsLearnMore": {
+        "message": "Learn more"
+    },
+    "fbusSensorsForwardingUnavailable": {
+        "message": "Forwarding needs an FrSky-family RX protocol -- set F.Port, F.Port2, or FBUS on the Receiver tab."
+    },
+    "fbusSensorsClear": {
+        "message": "Clear"
+    },
+    "fbusSensorsSlotsFull": {
+        "message": "All 8 forwarding slots are in use -- turn one off first."
+    },
+    "fbusSensorsColPhysicalId": {
+        "message": "Physical ID"
+    },
+    "fbusSensorsColSource": {
+        "message": "Source"
+    },
+    "fbusSensorsColName": {
+        "message": "Sensor Name"
+    },
+    "fbusSensorsColForwarded": {
+        "message": "Forwarded"
+    },
+    "fbusSensorsColAppIds": {
+        "message": "App IDs"
+    },
+    "fbusSensorsColPackets": {
+        "message": "Packets"
+    },
     "tabAdjustments": {
         "message": "Adjustments"
     },

--- a/src/js/fc.svelte.js
+++ b/src/js/fc.svelte.js
@@ -24,6 +24,8 @@ class FlightController {
   DEFAULT = $state();
   ESC_SENSOR_CONFIG = $state();
   FAILSAFE_CONFIG = $state();
+  FBUS_MASTER_CONFIG = $state();
+  FBUS_SENSORS = $state();
   FEATURE_CONFIG = $state();
   FILTER_CONFIG = $state();
   FLIGHT_STATS = $state();
@@ -161,6 +163,11 @@ class FlightController {
       voltageDropRate:            0,
       chargeDropRate:             0,
       sagGain:                    0,
+    };
+
+    this.FBUS_SENSORS = [];
+    this.FBUS_MASTER_CONFIG = {
+      forwardedSensors:            [],
     };
 
     this.ANALOG = {

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -46,6 +46,7 @@ export const GuiControl = function () {
         'gps',
         'led_strip',
         'blackbox',
+        'fbus_sensors',
         'modes',
         'motors',
         'governor',

--- a/src/js/help.js
+++ b/src/js/help.js
@@ -25,6 +25,7 @@ const tabHelpURLs = {
     tabGPS:             'https://www.rotorflight.org/docs/2.2.0/configurator/tabs/gps',
     tabSensors:         'https://www.rotorflight.org/docs/2.2.0/configurator/tabs/sensors',
     tabBlackbox:        'https://www.rotorflight.org/docs/2.2.0/configurator/tabs/blackbox',
+    tabFbusSensors:     'https://www.rotorflight.org/docs/2.2.0/configurator/tabs/fbus-sensors',
     tabCli:             'https://www.rotorflight.org/docs/2.2.0/configurator/tabs/cli',
 };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -431,6 +431,14 @@ function notifyOutdatedVersion(releaseData) {
 export function updateTabList(features) {
     $('#tabs ul.mode-connected li.tab_gps').toggle(features.isEnabled('GPS'));
     $('#tabs ul.mode-connected li.tab_led_strip').toggle(features.isEnabled('LED_STRIP'));
+
+    // FBUS/S.Port master mode observes sensors on a UART configured with the
+    // FBUS_OUT or SPORT_MASTER serial port function -- there's no dedicated
+    // feature bit for it.
+    const fbusMasterActive = (FC.SERIAL_CONFIG?.ports ?? []).some(
+        (port) => port.functions.includes('FBUS_OUT') || port.functions.includes('SPORT_MASTER'),
+    );
+    $('#tabs ul.mode-connected li.tab_fbus_sensors').toggle(fbusMasterActive);
 }
 
 function zeroPad(value, width) {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -214,4 +214,9 @@ export const MSPCodes = {
 //  MSP2_GET_VTX_DEVICE_STATUS:         0x3004,
     MSP2_SMARTFUEL_CONFIG:              0x4000,
     MSP2_SET_SMARTFUEL_CONFIG:          0x4001,
+
+    MSP2_GET_FBUS_SENSORS:               0x5F07,
+    MSP2_CLEAR_FBUS_SENSORS:             0x5F08,
+    MSP2_GET_FBUS_MASTER_CONFIG:         0x5F09,
+    MSP2_SET_FBUS_MASTER_CONFIG:         0x5F0A,
 };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -379,6 +379,59 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             }
 
+            case MSPCodes.MSP2_GET_FBUS_SENSORS: {
+                const count = data.readU8();
+                const sensors = [];
+
+                for (let i = 0; i < count; i++) {
+                    const sensor = {
+                        physicalId: data.readU8(),
+                        source: data.readU8(), // 0 = FBUS, 1 = S.Port
+                        forwarded: data.readU8() !== 0,
+                        packetCount: data.readU32(),
+                    };
+
+                    const nameLen = data.readU8();
+                    let name = '';
+                    for (let j = 0; j < nameLen; j++) {
+                        name += String.fromCharCode(data.readU8());
+                    }
+                    sensor.name = name;
+
+                    const appIdCount = data.readU8();
+                    sensor.appIds = [];
+                    for (let j = 0; j < appIdCount; j++) {
+                        sensor.appIds.push(data.readU16());
+                    }
+
+                    sensors.push(sensor);
+                }
+
+                FC.FBUS_SENSORS = sensors;
+                break;
+            }
+
+            case MSPCodes.MSP2_CLEAR_FBUS_SENSORS: {
+                console.log('Observed FBUS/S.Port sensors cleared');
+                break;
+            }
+
+            case MSPCodes.MSP2_GET_FBUS_MASTER_CONFIG: {
+                data.readU8(); // payload version, unused for now
+                const forwardedSensors = [];
+                // matches FBUS_MASTER_MAX_FORWARDED_SENSORS in pg/fbus_master.h
+                for (let i = 0; i < 8; i++) {
+                    forwardedSensors.push(data.readU8());
+                }
+                FC.FBUS_MASTER_CONFIG.forwardedSensors = forwardedSensors;
+                break;
+            }
+
+            case MSPCodes.MSP2_SET_FBUS_MASTER_CONFIG: {
+                console.log('FBUS master forwarding config saved');
+                break;
+            }
+
             case MSPCodes.MSP_SET_BATTERY_PROFILE: {
                 console.log('Battery profile set');
                 break;
@@ -967,6 +1020,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     };
                     FC.SERIAL_CONFIG.ports.push(serialPort);
                 }
+                updateTabList(FC.FEATURE_CONFIG.features);
                 break;
             }
 
@@ -2022,6 +2076,14 @@ MspHelper.prototype.crunch = function(code) {
                   .push8(FC.SMARTFUEL_CONFIG.voltageDropRate)
                   .push8(FC.SMARTFUEL_CONFIG.chargeDropRate)
                   .push8(FC.SMARTFUEL_CONFIG.sagGain);
+            break;
+        }
+
+        case MSPCodes.MSP2_SET_FBUS_MASTER_CONFIG: {
+            // matches FBUS_MASTER_MAX_FORWARDED_SENSORS in pg/fbus_master.h
+            for (let i = 0; i < 8; i++) {
+                buffer.push8(FC.FBUS_MASTER_CONFIG.forwardedSensors[i] ?? 0xFF);
+            }
             break;
         }
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -546,6 +546,10 @@ async function onConnect() {
         await MSP.promise(MSPCodes.MSP_BATTERY_CONFIG, false);
         await MSP.promise(MSPCodes.MSP_STATUS, false);
         await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY, false);
+        // Needed early (not just lazily per-tab) so the FBUS Sensors tab's
+        // visibility -- gated on an FBUS_OUT/SPORT_MASTER port -- is correct
+        // as soon as the tab list is shown.
+        await MSP.promise(MSPCodes.MSP_SERIAL_CONFIG, false);
 
         if (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2) {
             startLiveDataRefreshTimer();

--- a/src/js/tabs/fbus_sensors.js
+++ b/src/js/tabs/fbus_sensors.js
@@ -1,0 +1,41 @@
+import { mount, unmount } from "svelte";
+
+import { GUI } from "@/js/gui.js";
+import FbusSensors from "@/tabs/fbus_sensors/FbusSensors.svelte";
+
+import { TABS } from "./tabs.js";
+
+const tab = {
+  tabName: "fbus_sensors",
+  svelteComponent: null,
+
+  initialize(callback) {
+    const target = document.querySelector("#content");
+    target.innerHTML = "";
+    this.svelteComponent = mount(FbusSensors, { target });
+
+    GUI.content_ready(callback);
+  },
+
+  cleanup(callback) {
+    if (this.svelteComponent) {
+      unmount(this.svelteComponent);
+      this.svelteComponent = null;
+    }
+    callback?.();
+  },
+};
+
+TABS[tab.tabName] = tab;
+
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    if (newModule && GUI.active_tab === tab.tabName) {
+      TABS[tab.tabName].initialize();
+    }
+  });
+
+  import.meta.hot.dispose(() => {
+    tab.cleanup();
+  });
+}

--- a/src/js/tabs/index.js
+++ b/src/js/tabs/index.js
@@ -5,6 +5,7 @@ import "./blackbox.js";
 import "./cli.js";
 import "./configuration.js";
 import "./failsafe.js";
+import "./fbus_sensors.js";
 import "./firmware_flasher.js";
 import "./governor.js";
 import "./gps.js";

--- a/src/tabs/fbus_sensors/FbusSensors.svelte
+++ b/src/tabs/fbus_sensors/FbusSensors.svelte
@@ -1,0 +1,345 @@
+<script>
+  import { onDestroy, onMount } from "svelte";
+
+  import Page from "@/components/Page.svelte";
+  import Switch from "@/components/Switch.svelte";
+
+  import { FC } from "@/js/fc.svelte.js";
+  import { Features } from "@/js/features.svelte.js";
+  import { GUI } from "@/js/gui.js";
+  import { getTabHelpURL } from "@/js/help.js";
+  import { i18n } from "@/js/i18n.js";
+  import { MSP } from "@/js/msp.svelte.js";
+  import { MSPCodes } from "@/js/msp/MSPCodes.js";
+  import { mspHelper } from "@/js/msp/MSPHelper.js";
+  import { RX_PROTOCOLS } from "@/tabs/receiver/protocols.js";
+
+  // Mirrors fbusSensorGetSourceName() in drivers/fbus_sensor.c
+  const SOURCE_NAMES = ["FBUS", "S.Port"];
+
+  // Mirrors FBUS_MASTER_MAX_FORWARDED_SENSORS / FBUS_INVALID_PHYSICAL_ID in
+  // pg/fbus_master.h -- fixed-size slot array, 0xFF marks an empty slot.
+  const FORWARD_SLOT_COUNT = 8;
+  const EMPTY_SLOT = 0xff;
+
+  const POLL_INTERVAL_MS = 1000;
+
+  let loading = $state(true);
+  let supported = $state(true);
+  let clearing = $state(false);
+  let togglingKey = $state(null);
+  let pollerInterval;
+
+  let sensors = $derived(FC.FBUS_SENSORS ?? []);
+
+  // Forwarding relays sensor data back out over the receiver link's own
+  // telemetry return channel (rx/fbus.c), which only exists for FrSky-family
+  // protocols (F.Port/F.Port2/FBUS, and the FrSky RX-SPI variants). Reading
+  // sensors as an FBUS/S.Port master works regardless of RX protocol --
+  // that's a separate UART -- but forwarding specifically needs this.
+  // Mirrors the active-protocol lookup in Receiver.svelte.
+  let rxFeature = $derived.by(() => {
+    for (const f of Features.GROUPS.RX_PROTO) {
+      if (FC.FEATURE_CONFIG.features[f]) {
+        return f;
+      }
+    }
+  });
+
+  let rxProto = $derived.by(() => {
+    if (!rxFeature) {
+      return null;
+    }
+
+    for (let i = 1; i < RX_PROTOCOLS.length; i++) {
+      const proto = RX_PROTOCOLS[i];
+      if (proto.feature !== rxFeature) {
+        continue;
+      }
+
+      if (
+        rxFeature === "RX_SERIAL" &&
+        proto.id !== FC.RX_CONFIG.serialrx_provider
+      ) {
+        continue;
+      }
+
+      if (rxFeature === "RX_SPI" && proto.id !== FC.RX_CONFIG.rxSpiProtocol) {
+        continue;
+      }
+
+      return proto;
+    }
+
+    return null;
+  });
+
+  let canForward = $derived(rxProto?.telemetry?.proto === "smartport");
+
+  function sourceName(source) {
+    return SOURCE_NAMES[source] ?? `ID_${source}`;
+  }
+
+  function rowKey(sensor) {
+    return `${sensor.source}-${sensor.physicalId}`;
+  }
+
+  async function refresh() {
+    const response = await MSP.promise(MSPCodes.MSP2_GET_FBUS_SENSORS);
+    // Older firmware without this command simply won't populate any data.
+    if (!response || response.length === 0) {
+      supported = false;
+    }
+  }
+
+  async function refreshForwardConfig() {
+    await MSP.promise(MSPCodes.MSP2_GET_FBUS_MASTER_CONFIG);
+  }
+
+  async function onClickClear() {
+    clearing = true;
+    try {
+      await MSP.promise(MSPCodes.MSP2_CLEAR_FBUS_SENSORS);
+      await refresh();
+    } finally {
+      clearing = false;
+    }
+  }
+
+  async function toggleForwarding(sensor) {
+    if (togglingKey || !canForward) {
+      return;
+    }
+
+    const slots = [...(FC.FBUS_MASTER_CONFIG.forwardedSensors ?? [])];
+    while (slots.length < FORWARD_SLOT_COUNT) {
+      slots.push(EMPTY_SLOT);
+    }
+
+    if (sensor.forwarded) {
+      const slotIndex = slots.indexOf(sensor.physicalId);
+      if (slotIndex === -1) {
+        return;
+      }
+      slots[slotIndex] = EMPTY_SLOT;
+    } else {
+      const freeIndex = slots.indexOf(EMPTY_SLOT);
+      if (freeIndex === -1) {
+        GUI.log($i18n.t("fbusSensorsSlotsFull"));
+        return;
+      }
+      slots[freeIndex] = sensor.physicalId;
+    }
+
+    togglingKey = rowKey(sensor);
+    try {
+      FC.FBUS_MASTER_CONFIG.forwardedSensors = slots;
+      await MSP.promise(
+        MSPCodes.MSP2_SET_FBUS_MASTER_CONFIG,
+        mspHelper.crunch(MSPCodes.MSP2_SET_FBUS_MASTER_CONFIG),
+      );
+      await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+      await Promise.all([refresh(), refreshForwardConfig()]);
+    } finally {
+      togglingKey = null;
+    }
+  }
+
+  function onClickHelp() {
+    window.open(getTabHelpURL("tabFbusSensors"), "_system");
+  }
+
+  onMount(async () => {
+    await MSP.promise(MSPCodes.MSP_RX_CONFIG);
+    await Promise.all([refresh(), refreshForwardConfig()]);
+    loading = false;
+
+    pollerInterval = setInterval(refresh, POLL_INTERVAL_MS);
+  });
+
+  onDestroy(() => {
+    clearInterval(pollerInterval);
+  });
+</script>
+
+{#snippet header()}
+  <h1>{$i18n.t("tabFbusSensors")}</h1>
+  <div class="grow"></div>
+  <button class="btn help-btn" onclick={onClickHelp}>
+    {$i18n.t("buttonHelp")}
+  </button>
+{/snippet}
+
+{#snippet toolbar()}
+  <button class="btn" onclick={onClickClear} disabled={clearing}>
+    {$i18n.t("fbusSensorsClear")}
+  </button>
+{/snippet}
+
+<Page {header} {loading} {toolbar}>
+  {#if !supported}
+    <p class="note">{$i18n.t("fbusSensorsNotSupported")}</p>
+  {:else}
+    <p class="description">
+      {$i18n.t("fbusSensorsDescription")}
+      <a
+        class="learn-more"
+        href={getTabHelpURL("tabFbusSensors")}
+        target="_system"
+      >
+        {$i18n.t("fbusSensorsLearnMore")}
+      </a>
+    </p>
+
+    {#if sensors.length === 0}
+      <p class="note">{$i18n.t("fbusSensorsEmpty")}</p>
+    {:else}
+      <div class="table-wrap">
+        <table class="grid">
+          <thead>
+            <tr>
+              <th>{$i18n.t("fbusSensorsColPhysicalId")}</th>
+              <th>{$i18n.t("fbusSensorsColSource")}</th>
+              <th>{$i18n.t("fbusSensorsColName")}</th>
+              <th>{$i18n.t("fbusSensorsColAppIds")}</th>
+              <th>{$i18n.t("fbusSensorsColPackets")}</th>
+              <th>{$i18n.t("fbusSensorsColForwarded")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each sensors as sensor (rowKey(sensor))}
+              <tr>
+                <td>{sensor.physicalId}</td>
+                <td>{sourceName(sensor.source)}</td>
+                <td class="name">{sensor.name}</td>
+                <td class="app-ids">{sensor.appIds.join(", ")}</td>
+                <td>{sensor.packetCount}</td>
+                <td
+                  class:dimmed={!canForward}
+                  title={!canForward
+                    ? $i18n.t("fbusSensorsForwardingUnavailable")
+                    : undefined}
+                >
+                  <Switch
+                    checked={sensor.forwarded}
+                    disabled={!canForward ||
+                      (togglingKey !== null && togglingKey !== rowKey(sensor))}
+                    onchange={() => toggleForwarding(sensor)}
+                  />
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
+</Page>
+
+<style lang="scss">
+  h1 {
+    font-weight: 600;
+  }
+
+  .grow {
+    flex-grow: 1;
+  }
+
+  .btn {
+    @extend %button;
+  }
+
+  .help-btn {
+    min-width: 60px;
+  }
+
+  .description {
+    margin-top: var(--section-gap);
+    margin-bottom: var(--section-gap);
+    padding: 8px 12px;
+    border-radius: 4px;
+
+    color: var(--color-text-soft);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+  }
+
+  .learn-more {
+    color: var(--color-border-accent);
+    white-space: nowrap;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .note {
+    margin-top: var(--section-gap);
+    margin-bottom: var(--section-gap);
+    padding: 8px 12px;
+    border-radius: 4px;
+
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border-accent);
+  }
+
+  .table-wrap {
+    @extend %section-shadow;
+
+    overflow-x: auto;
+    border-radius: 4px;
+    background-color: var(--color-surface);
+  }
+
+  .grid {
+    width: 100%;
+    min-width: 640px;
+    border-collapse: collapse;
+  }
+
+  th {
+    padding: 6px 12px;
+    font-weight: 700;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    text-align: left;
+    white-space: nowrap;
+
+    /* surface-alt is a dark band in both themes -- text-alt is the token
+       for text on it (the same one the shared section-header mixin uses),
+       giving near-white headers in both themes. Plain text-soft/text read
+       near-black here in light theme since they're tuned for the light
+       surface, not this band. */
+    color: var(--color-text-alt);
+    background-color: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  td {
+    padding: 6px 12px;
+    font-size: 0.85rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  /* Opacity rather than recoloring the switch itself -- reliably dims it
+     regardless of checked/disabled state, sidestepping Switch.svelte's own
+     checked-color vs. disabled-color specificity. */
+  td.dimmed {
+    opacity: 0.45;
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+
+  .name {
+    font-weight: 600;
+  }
+
+  .app-ids {
+    color: var(--color-text-soft);
+    font-variant-numeric: tabular-nums;
+  }
+</style>


### PR DESCRIPTION
## Summary

Adds a live "FBUS/S.Port Sensors" diagnostic/control tab -- a table (Physical ID, Source, Sensor Name, App IDs, Packets) polled once a second, with a Clear action, backed by the new `MSP2_GET_FBUS_SENSORS`/`MSP2_CLEAR_FBUS_SENSORS` commands.

Also exposes sensor forwarding control (`MSP2_GET_FBUS_MASTER_CONFIG`/`MSP2_SET_FBUS_MASTER_CONFIG`), previously CLI-only via `set fbus_master_forwarded_sensors`:

- A Forwarded toggle per sensor applies immediately (SET + EEPROM write, firmware reloads forwarding buffers live -- no reboot) and persists.
- Blocks with a message when all 8 forward slots are full rather than silently evicting one.
- The toggle is disabled (and its cell dimmed) unless the RX protocol is FrSky-family (F.Port/F.Port2/FBUS) -- forwarding rides that protocol's own telemetry return channel, which other protocols don't have. Hovering explains why; reading/using sensors directly works regardless of RX protocol.

Tab visibility is gated on a serial port having the `FBUS_OUT`/`SPORT_MASTER` function assigned, wired into `updateTabList()` on connect and whenever serial config changes.

Companion firmware PR (adds the MSP commands this tab uses): rotorflight/rotorflight-firmware#482

## Testing

`eslint` and a production `vite build` both pass cleanly.
