### PR TITLE
feat: add CRSF Sensors diagnostic tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,6 +222,7 @@
                     <li class="tab_beepers"><a href="#" i18n="tabBeepers" class="tabicon ic_beepers" i18n_title="tabBeepers"></a></li>
                     <li class="tab_gps"><a href="#" i18n="tabGPS" class="tabicon ic_gps" i18n_title="tabGPS"></a></li>
                     <li class="tab_sensors"><a href="#" i18n="tabRawSensorData" class="tabicon ic_sensors" i18n_title="tabRawSensorData"></a></li>
+                    <li class="tab_crsf_sensors"><a href="#" i18n="tabCrsfSensors" class="tabicon ic_sensors" i18n_title="tabCrsfSensors"></a></li>
                     <li class="tab_blackbox"><a href="#" i18n="tabBlackbox" class="tabicon ic_data" i18n_title="tabBlackbox"></a></li>
                     <!-- spare icons
                     <li class=""><a href="#"class="tabicon ic_mission">Mission (spare icon)</a></li>

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -474,6 +474,120 @@
     "tabRawSensorData": {
         "message": "Sensors"
     },
+    "tabCrsfSensors": {
+        "message": "CRSF Sensors"
+    },
+    "crsfSensorsDescription": {
+        "message": "Live link diagnostics and decoded readings from a CRSF-protocol sensor accessory (GPS, battery, barometer, or per-cell voltage) wired to the CRSF Sensors serial port."
+    },
+    "crsfSensorsLearnMore": {
+        "message": "Learn more"
+    },
+    "crsfSensorsNotSupported": {
+        "message": "This firmware does not support the CRSF Sensors diagnostic."
+    },
+    "crsfSensorsPortNotConfigured": {
+        "message": "No serial port is assigned the CRSF Sensors function yet -- set one on the Configuration tab."
+    },
+    "crsfSensorsBadgeReceiving": {
+        "message": "Receiving"
+    },
+    "crsfSensorsBadgeNoData": {
+        "message": "No data"
+    },
+    "crsfSensorsBadgePortEnabled": {
+        "message": "Port enabled"
+    },
+    "crsfSensorsBadgePortDisabled": {
+        "message": "Port disabled"
+    },
+    "crsfSensorsLinkTitle": {
+        "message": "Link"
+    },
+    "crsfSensorsRxBytes": {
+        "message": "RX bytes"
+    },
+    "crsfSensorsRxSyncBytes": {
+        "message": "RX sync bytes"
+    },
+    "crsfSensorsCrcOk": {
+        "message": "CRC OK frames"
+    },
+    "crsfSensorsCrcFail": {
+        "message": "CRC fail"
+    },
+    "crsfSensorsLastFrame": {
+        "message": "Last frame type/len"
+    },
+    "crsfSensorsNoData": {
+        "message": "No data received yet"
+    },
+    "crsfSensorsGpsTitle": {
+        "message": "GPS"
+    },
+    "crsfSensorsGpsLat": {
+        "message": "Latitude"
+    },
+    "crsfSensorsGpsLon": {
+        "message": "Longitude"
+    },
+    "crsfSensorsGpsSpeed": {
+        "message": "Ground speed"
+    },
+    "crsfSensorsGpsHeading": {
+        "message": "Heading"
+    },
+    "crsfSensorsGpsAlt": {
+        "message": "Altitude"
+    },
+    "crsfSensorsGpsSats": {
+        "message": "Satellites"
+    },
+    "crsfSensorsBatteryTitle": {
+        "message": "Battery"
+    },
+    "crsfSensorsBatteryVoltage": {
+        "message": "Voltage"
+    },
+    "crsfSensorsBatteryCurrent": {
+        "message": "Current"
+    },
+    "crsfSensorsBatteryCapacity": {
+        "message": "Capacity used"
+    },
+    "crsfSensorsBatteryRemaining": {
+        "message": "Remaining"
+    },
+    "crsfSensorsBaroTitle": {
+        "message": "Barometer"
+    },
+    "crsfSensorsBaroAlt": {
+        "message": "Altitude"
+    },
+    "crsfSensorsBaroVspeed": {
+        "message": "Vertical speed"
+    },
+    "crsfSensorsCellsTitle": {
+        "message": "Cell Voltages"
+    },
+    "crsfSensorsCellsCount": {
+        "message": "Cell count"
+    },
+    "crsfSensorsCellsTotal": {
+        "message": "Total voltage"
+    },
+    "crsfSensorsCellsChip": {
+        "message": "Cell $1"
+    },
+    "crsfSensorsRpmTitle": {
+        "message": "RPM"
+    },
+    "crsfSensorsRpmChip": {
+        "message": "Source $1"
+    },
+    "crsfSensorsRpmCaveat": {
+        "message": "Set crsf_sensors_use_rpm = ON (CLI-only) to feed this into blackbox, telemetry, RPM Filter, and the Governor. Telemetry-rate, not motor-rate -- use at your own risk for RPM Filter or the Governor's RPM modes, both of which need bidirectional DShot or a dedicated RPM/frequency sensor to actually track real motor speed."
+    },
     "tabCLI": {
         "message": "CLI"
     },

--- a/src/js/fc.svelte.js
+++ b/src/js/fc.svelte.js
@@ -17,6 +17,7 @@ class FlightController {
   BUS_SERVO_CONFIG = $state();
   CONFIG = $state();
   COPY_PROFILE = $state();
+  CRSF_SENSORS_STATUS = $state();
   CURRENT_METERS = $state();
   CURRENT_METER_CONFIGS = $state();
   DATAFLASH = $state();
@@ -348,6 +349,21 @@ class FlightController {
       consumption:                [0, 0, 0, 0, 0, 0, 0, 0],
       temperature:                [0, 0, 0, 0, 0, 0, 0, 0],
       temperature2:               [0, 0, 0, 0, 0, 0, 0, 0],
+    };
+
+    this.CRSF_SENSORS_STATUS = {
+      enabled:                    false,
+      rxByteCount:                0,
+      rxSyncCount:                0,
+      rxCrcOkCount:               0,
+      rxCrcFailCount:             0,
+      lastFrameType:              0,
+      lastFrameLength:            0,
+      gps:                        null,
+      battery:                    null,
+      baro:                       null,
+      cells:                      null,
+      rpm:                        null,
     };
 
     this.GPS_DATA = {

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -46,6 +46,7 @@ export const GuiControl = function () {
         'gps',
         'led_strip',
         'blackbox',
+        'crsf_sensors',
         'modes',
         'motors',
         'governor',

--- a/src/js/help.js
+++ b/src/js/help.js
@@ -25,6 +25,7 @@ const tabHelpURLs = {
     tabBeepers:         `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/beepers`,
     tabGPS:             `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/gps`,
     tabSensors:         `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/sensors`,
+    tabCrsfSensors:     `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/crsf-sensors`,
     tabBlackbox:        `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/blackbox`,
     tabCli:             `https://www.rotorflight.org/docs${docsVersionSpecifier}/configurator/tabs/cli`,
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -431,6 +431,11 @@ function notifyOutdatedVersion(releaseData) {
 export function updateTabList(features) {
     $('#tabs ul.mode-connected li.tab_gps').toggle(features.isEnabled('GPS'));
     $('#tabs ul.mode-connected li.tab_led_strip').toggle(features.isEnabled('LED_STRIP'));
+
+    const hasCrsfSensorsPort = (FC.SERIAL_CONFIG?.ports ?? []).some(
+        (port) => port.functions.includes('CRSF_SENSORS'),
+    );
+    $('#tabs ul.mode-connected li.tab_crsf_sensors').toggle(hasCrsfSensorsPort);
 }
 
 function zeroPad(value, width) {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -214,4 +214,6 @@ export const MSPCodes = {
 //  MSP2_GET_VTX_DEVICE_STATUS:         0x3004,
     MSP2_SMARTFUEL_CONFIG:              0x4000,
     MSP2_SET_SMARTFUEL_CONFIG:          0x4001,
+
+    MSP2_GET_CRSF_SENSORS_STATUS:       0x5F0B,
 };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -68,6 +68,7 @@ export function MspHelper() {
         'SBUS_OUT': 18,
         'FBUS_OUT': 19,
         'SPORT_MASTER': 20,
+        'CRSF_SENSORS': 22,
     };
 
     self.REBOOT_TYPES = {
@@ -376,6 +377,101 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP2_SET_SMARTFUEL_CONFIG: {
                 console.log('Smart Fuel configuration saved');
+                break;
+            }
+
+            case MSPCodes.MSP2_GET_CRSF_SENSORS_STATUS: {
+                data.readU8(); // payload version, unused for now
+                const enabled = data.readU8() !== 0;
+                const rxByteCount = data.readU32();
+                const rxSyncCount = data.readU32();
+                const rxCrcOkCount = data.readU32();
+                const rxCrcFailCount = data.readU32();
+                const lastFrameType = data.readU8();
+                const lastFrameLength = data.readU8();
+
+                let gps = null;
+                if (data.readU8() !== 0) {
+                    gps = {
+                        latitude: data.read32(),
+                        longitude: data.read32(),
+                        groundspeedCmS: data.readU16(),
+                        headingDeg10: data.readU16(),
+                        altitudeCm: data.read32(),
+                        satellites: data.readU8(),
+                    };
+                } else {
+                    data.read32();
+                    data.read32();
+                    data.readU16();
+                    data.readU16();
+                    data.read32();
+                    data.readU8();
+                }
+
+                let battery = null;
+                if (data.readU8() !== 0) {
+                    battery = {
+                        voltageMv: data.readU32(),
+                        currentMa: data.readU32(),
+                        capacityMah: data.readU32(),
+                        remainingPct: data.readU8(),
+                    };
+                } else {
+                    data.readU32();
+                    data.readU32();
+                    data.readU32();
+                    data.readU8();
+                }
+
+                let baro = null;
+                if (data.readU8() !== 0) {
+                    baro = {
+                        altitudeCm: data.read32(),
+                        verticalSpeedCmS: data.read16(),
+                    };
+                } else {
+                    data.read32();
+                    data.read16();
+                }
+
+                let cells = null;
+                const hasCells = data.readU8() !== 0;
+                const cellCount = data.readU8();
+                const cellVoltageMv = [];
+                for (let i = 0; i < cellCount; i++) {
+                    cellVoltageMv.push(data.readU16());
+                }
+                const totalVoltageMv = data.readU32();
+                if (hasCells) {
+                    cells = { cellCount, cellVoltageMv, totalVoltageMv };
+                }
+
+                let rpm = null;
+                const hasRpm = data.readU8() !== 0;
+                const rpmCount = data.readU8();
+                const rpmValues = [];
+                for (let i = 0; i < rpmCount; i++) {
+                    rpmValues.push(data.read32());
+                }
+                if (hasRpm) {
+                    rpm = { rpmCount, rpmValues };
+                }
+
+                FC.CRSF_SENSORS_STATUS = {
+                    enabled,
+                    rxByteCount,
+                    rxSyncCount,
+                    rxCrcOkCount,
+                    rxCrcFailCount,
+                    lastFrameType,
+                    lastFrameLength,
+                    gps,
+                    battery,
+                    baro,
+                    cells,
+                    rpm,
+                };
                 break;
             }
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -280,6 +280,7 @@ tab.initialize = function (callback) {
         { id: 524288,excl: 524288,  name: 'FBUS_OUT',             type: portTypes.AUTO },
         { id: 1048576, excl: 1048576, name: 'SPORT_MASTER',       type: portTypes.AUTO },
         { id: 2097152,excl: 2097152,name: 'SRXL2_ESC',            type: portTypes.AUTO },
+        { id: 4194304,excl: 4194304,name: 'CRSF_SENSORS',         type: portTypes.AUTO },
         { id: 4,     excl: 4668,    name: 'TELEMETRY_FRSKY',      type: portTypes.TELEM },
         { id: 32,    excl: 4668,    name: 'TELEMETRY_SMARTPORT',  type: portTypes.TELEM },
         { id: 4096,  excl: 4668,    name: 'TELEMETRY_IBUS',       type: portTypes.TELEM },

--- a/src/js/tabs/crsf_sensors.js
+++ b/src/js/tabs/crsf_sensors.js
@@ -1,0 +1,42 @@
+import { mount, unmount } from "svelte";
+
+import CrsfSensors from "@/tabs/crsf_sensors/CrsfSensors.svelte";
+
+import { GUI } from "@/js/gui.js";
+
+import { TABS } from "./tabs.js";
+
+const tab = {
+  tabName: "crsf_sensors",
+  svelteComponent: null,
+
+  initialize(callback) {
+    const target = document.querySelector("#content");
+    target.innerHTML = "";
+    this.svelteComponent = mount(CrsfSensors, { target });
+
+    GUI.content_ready(callback);
+  },
+
+  cleanup(callback) {
+    if (this.svelteComponent) {
+      unmount(this.svelteComponent);
+      this.svelteComponent = null;
+    }
+    callback?.();
+  },
+};
+
+TABS[tab.tabName] = tab;
+
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    if (newModule && GUI.active_tab === tab.tabName) {
+      TABS[tab.tabName].initialize();
+    }
+  });
+
+  import.meta.hot.dispose(() => {
+    tab.cleanup();
+  });
+}

--- a/src/js/tabs/index.js
+++ b/src/js/tabs/index.js
@@ -4,6 +4,7 @@ import "./beepers.js";
 import "./blackbox.js";
 import "./cli.js";
 import "./configuration.js";
+import "./crsf_sensors.js";
 import "./failsafe.js";
 import "./firmware_flasher.js";
 import "./governor.js";

--- a/src/tabs/crsf_sensors/CrsfSensors.svelte
+++ b/src/tabs/crsf_sensors/CrsfSensors.svelte
@@ -1,0 +1,423 @@
+<script>
+  import { onDestroy, onMount } from "svelte";
+
+  import Page from "@/components/Page.svelte";
+
+  import { FC } from "@/js/fc.svelte.js";
+  import { getTabHelpURL } from "@/js/help.js";
+  import { i18n } from "@/js/i18n.js";
+  import { MSP } from "@/js/msp.svelte.js";
+  import { MSPCodes } from "@/js/msp/MSPCodes.js";
+
+  const POLL_INTERVAL_MS = 500;
+
+  let loading = $state(true);
+  let supported = $state(true);
+  let pollerInterval;
+
+  let status = $derived(FC.CRSF_SENSORS_STATUS ?? {});
+
+  function mv(value) {
+    return `${(value / 1000).toFixed(3)} V`;
+  }
+
+  function hex(value) {
+    return `0x${value.toString(16).padStart(2, "0")}`;
+  }
+
+  async function refresh() {
+    const response = await MSP.promise(MSPCodes.MSP2_GET_CRSF_SENSORS_STATUS);
+    // Older firmware without this command simply won't populate any data.
+    if (!response || response.length === 0) {
+      supported = false;
+    }
+  }
+
+  function onClickHelp() {
+    window.open(getTabHelpURL("tabCrsfSensors"), "_system");
+  }
+
+  onMount(async () => {
+    await refresh();
+    loading = false;
+
+    pollerInterval = setInterval(refresh, POLL_INTERVAL_MS);
+  });
+
+  onDestroy(() => {
+    clearInterval(pollerInterval);
+  });
+</script>
+
+{#snippet header()}
+  <h1>{$i18n.t("tabCrsfSensors")}</h1>
+  <div class="grow"></div>
+  <button class="btn help-btn" onclick={onClickHelp}>
+    {$i18n.t("buttonHelp")}
+  </button>
+{/snippet}
+
+<Page {header} {loading}>
+  {#if !supported}
+    <p class="note">{$i18n.t("crsfSensorsNotSupported")}</p>
+  {:else}
+    <p class="description">
+      {$i18n.t("crsfSensorsDescription")}
+      <a
+        class="learn-more"
+        href={getTabHelpURL("tabCrsfSensors")}
+        target="_system"
+      >
+        {$i18n.t("crsfSensorsLearnMore")}
+      </a>
+    </p>
+
+    {#if !status.enabled}
+      <p class="note">{$i18n.t("crsfSensorsPortNotConfigured")}</p>
+    {/if}
+
+    {#snippet sectionHeader(titleKey, badgeUp)}
+      <div class="section-header">
+        <span class="title">{$i18n.t(titleKey)}</span>
+        <div class="grow"></div>
+        <span class="badge" class:up={badgeUp} class:down={!badgeUp}>
+          {badgeUp
+            ? $i18n.t("crsfSensorsBadgeReceiving")
+            : $i18n.t("crsfSensorsBadgeNoData")}
+        </span>
+      </div>
+    {/snippet}
+
+    <div class="card">
+      <div class="section-header">
+        <span class="title">{$i18n.t("crsfSensorsLinkTitle")}</span>
+        <div class="grow"></div>
+        <span
+          class="badge"
+          class:up={status.enabled}
+          class:down={!status.enabled}
+        >
+          {status.enabled
+            ? $i18n.t("crsfSensorsBadgePortEnabled")
+            : $i18n.t("crsfSensorsBadgePortDisabled")}
+        </span>
+      </div>
+      <div class="grid">
+        <div class="stat">
+          <span class="label">{$i18n.t("crsfSensorsRxBytes")}</span>
+          <span class="value">{status.rxByteCount ?? 0}</span>
+        </div>
+        <div class="stat">
+          <span class="label">{$i18n.t("crsfSensorsRxSyncBytes")}</span>
+          <span class="value">{status.rxSyncCount ?? 0}</span>
+        </div>
+        <div class="stat">
+          <span class="label">{$i18n.t("crsfSensorsCrcOk")}</span>
+          <span class="value">{status.rxCrcOkCount ?? 0}</span>
+        </div>
+        <div class="stat">
+          <span class="label">{$i18n.t("crsfSensorsCrcFail")}</span>
+          <span class="value" class:warn={(status.rxCrcFailCount ?? 0) > 0}
+            >{status.rxCrcFailCount ?? 0}</span
+          >
+        </div>
+        <div class="stat">
+          <span class="label">{$i18n.t("crsfSensorsLastFrame")}</span>
+          <span class="value"
+            >{hex(status.lastFrameType ?? 0)} / {status.lastFrameLength ??
+              0}</span
+          >
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      {@render sectionHeader("crsfSensorsGpsTitle", !!status.gps)}
+      {#if status.gps}
+        <div class="grid">
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsLat")}</span>
+            <span class="value">{(status.gps.latitude / 1e7).toFixed(6)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsLon")}</span>
+            <span class="value">{(status.gps.longitude / 1e7).toFixed(6)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsSpeed")}</span>
+            <span class="value"
+              >{(status.gps.groundspeedCmS / 100).toFixed(1)} m/s</span
+            >
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsHeading")}</span>
+            <span class="value"
+              >{(status.gps.headingDeg10 / 10).toFixed(1)}°</span
+            >
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsAlt")}</span>
+            <span class="value"
+              >{(status.gps.altitudeCm / 100).toFixed(1)} m</span
+            >
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsGpsSats")}</span>
+            <span class="value">{status.gps.satellites}</span>
+          </div>
+        </div>
+      {:else}
+        <p class="empty">{$i18n.t("crsfSensorsNoData")}</p>
+      {/if}
+    </div>
+
+    <div class="card">
+      {@render sectionHeader("crsfSensorsBatteryTitle", !!status.battery)}
+      {#if status.battery}
+        <div class="grid">
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBatteryVoltage")}</span>
+            <span class="value">{mv(status.battery.voltageMv)}</span>
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBatteryCurrent")}</span>
+            <span class="value"
+              >{(status.battery.currentMa / 1000).toFixed(2)} A</span
+            >
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBatteryCapacity")}</span>
+            <span class="value">{status.battery.capacityMah} mAh</span>
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBatteryRemaining")}</span>
+            <span class="value">{status.battery.remainingPct}%</span>
+          </div>
+        </div>
+      {:else}
+        <p class="empty">{$i18n.t("crsfSensorsNoData")}</p>
+      {/if}
+    </div>
+
+    <div class="card">
+      {@render sectionHeader("crsfSensorsBaroTitle", !!status.baro)}
+      {#if status.baro}
+        <div class="grid">
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBaroAlt")}</span>
+            <span class="value"
+              >{(status.baro.altitudeCm / 100).toFixed(1)} m</span
+            >
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsBaroVspeed")}</span>
+            <span class="value"
+              >{(status.baro.verticalSpeedCmS / 100).toFixed(2)} m/s</span
+            >
+          </div>
+        </div>
+      {:else}
+        <p class="empty">{$i18n.t("crsfSensorsNoData")}</p>
+      {/if}
+    </div>
+
+    <div class="card">
+      {@render sectionHeader("crsfSensorsCellsTitle", !!status.cells)}
+      {#if status.cells}
+        <div class="grid">
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsCellsCount")}</span>
+            <span class="value">{status.cells.cellCount}</span>
+          </div>
+          <div class="stat">
+            <span class="label">{$i18n.t("crsfSensorsCellsTotal")}</span>
+            <span class="value">{mv(status.cells.totalVoltageMv)}</span>
+          </div>
+        </div>
+        <div class="cell-list">
+          {#each status.cells.cellVoltageMv as cellVoltage, i (i)}
+            <span class="cell-chip">
+              {$i18n.t("crsfSensorsCellsChip", { 1: i + 1 })}: {mv(cellVoltage)}
+            </span>
+          {/each}
+        </div>
+      {:else}
+        <p class="empty">{$i18n.t("crsfSensorsNoData")}</p>
+      {/if}
+    </div>
+
+    <div class="card">
+      {@render sectionHeader("crsfSensorsRpmTitle", !!status.rpm)}
+      {#if status.rpm}
+        <div class="cell-list">
+          {#each status.rpm.rpmValues as rpmValue, i (i)}
+            <span class="cell-chip">
+              {$i18n.t("crsfSensorsRpmChip", { 1: i + 1 })}: {rpmValue} RPM
+            </span>
+          {/each}
+        </div>
+        <p class="rpm-caveat">{$i18n.t("crsfSensorsRpmCaveat")}</p>
+      {:else}
+        <p class="empty">{$i18n.t("crsfSensorsNoData")}</p>
+      {/if}
+    </div>
+  {/if}
+</Page>
+
+<style lang="scss">
+  h1 {
+    font-weight: 600;
+  }
+
+  .grow {
+    flex-grow: 1;
+  }
+
+  .btn {
+    @extend %button;
+  }
+
+  .help-btn {
+    min-width: 60px;
+  }
+
+  .description {
+    margin-top: var(--section-gap);
+    margin-bottom: var(--section-gap);
+    padding: 8px 12px;
+    border-radius: 4px;
+
+    color: var(--color-text-soft);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border);
+  }
+
+  .learn-more {
+    color: var(--color-border-accent);
+    white-space: nowrap;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .note {
+    margin-top: var(--section-gap);
+    margin-bottom: var(--section-gap);
+    padding: 8px 12px;
+    border-radius: 4px;
+
+    color: var(--color-text);
+    background-color: var(--color-surface);
+    border: 1px solid var(--color-border-accent);
+  }
+
+  .card {
+    @extend %section-shadow;
+
+    margin-bottom: var(--section-gap);
+    border-radius: 4px;
+    background-color: var(--color-surface);
+    overflow: hidden;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+
+    color: var(--color-text-alt);
+    background-color: var(--color-surface-alt);
+    border-bottom: 1px solid var(--color-border);
+
+    .title {
+      font-weight: 700;
+      font-size: 0.75rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+  }
+
+  .badge {
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--color-text);
+    background-color: var(--color-bg);
+    border: 1px solid var(--color-border);
+
+    &.up {
+      color: var(--color-border-accent);
+      border-color: var(--color-border-accent);
+    }
+
+    &.down {
+      color: var(--color-danger, var(--color-border-accent));
+      border-color: var(--color-danger, var(--color-border-accent));
+    }
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 1px;
+    background-color: var(--color-border);
+  }
+
+  .stat {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 12px;
+    background-color: var(--color-surface);
+  }
+
+  .label {
+    font-size: 0.68rem;
+    color: var(--color-text-soft);
+    white-space: nowrap;
+  }
+
+  .value {
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+
+    &.warn {
+      color: var(--color-danger, var(--color-border-accent));
+    }
+  }
+
+  .empty {
+    padding: 12px;
+    margin: 0;
+    color: var(--color-text-soft);
+    font-size: 0.85rem;
+  }
+
+  .cell-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px 12px;
+  }
+
+  .cell-chip {
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+
+    color: var(--color-text);
+    background-color: var(--color-bg);
+    border: 1px solid var(--color-border);
+  }
+
+  .rpm-caveat {
+    margin: 0;
+    padding: 0 12px 12px;
+    font-size: 0.75rem;
+    color: var(--color-danger, var(--color-text-soft));
+  }
+</style>


### PR DESCRIPTION
Companion to [rotorflight-firmware#497](https://github.com/rotorflight/rotorflight-firmware/pull/497), which adds the CRSF Sensors driver and this tab's backing MSP command.

## What this adds
New **CRSF Sensors** diagnostic tab (next to Sensors), visible once a UART is assigned the CRSF Sensors port function on the Configuration tab. Polls `MSP2_GET_CRSF_SENSORS_STATUS` (`0x5F0B`, next free in this repo's own custom MSP2 range) twice a second and shows:

- **Link** health: enabled state, rx byte/sync/CRC counters — useful for diagnosing wiring/baud/protocol issues without a logic analyzer.
- **GPS / Battery / Barometer / Cell Voltages / RPM** cards, each with a Receiving/No data badge and the latest decoded values.

Ported from a fork ([WingFlight](https://github.com/WingFlight/wingflight-configurator)) where this was built and tested against real hardware, including a real wiring/decode debugging session using an earlier, simpler version of this same page.

## Also fixed
`configuration.js`'s port-function list and `MSPHelper.js`'s `SERIAL_PORT_FUNCTIONS` map didn't have `CRSF_SENSORS` (bit 22 / `4194304`, added in the companion firmware PR) — both updated to match.

## Companion PRs
- Firmware: rotorflight/rotorflight-firmware#497
- Lua ETHOS suite: rotorflight/rotorflight-lua-ethos-suite#2294

🤖 Generated with [Claude Code](https://claude.com/claude-code)
